### PR TITLE
Allow semgrep scans for pull requests from forked repos.

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,8 @@
 on:
-  pull_request: {}
+  # Give access to the semgrep token (and other GitHub secrets!) to
+  # strangers making pull requests.
+  pull_request_target: {}
+
   push:
     branches:
     - main


### PR DESCRIPTION
I also [changed `GITHUB_TOKEN`](https://github.com/returntocorp/ocaml-tree-sitter-core/settings/actions) to only grant read-only access to the repo. This will affect other GitHub Actions workflows, if any. Right now, we have only one GHA workflow, it's the semgrep scan. Other CI jobs are done by CircleCI.
