### PR TITLE
Require newer bash

### DIFF
--- a/scripts/check-prerequisites
+++ b/scripts/check-prerequisites
@@ -14,7 +14,8 @@ EOF
 
 echo "Check for bash arrays."
 bash --version
-things[0]='' || error "Please upgrade bash. Bash version must be >= 4.0."
+things=() || error "Please upgrade bash. Bash version must be >= 4.4."
+("${things[@]}") || error "Please upgrade bash. Bash version must be >= 4.4."
 
 echo "Check for 'which'."
 which which || error "Missing command: which"


### PR DESCRIPTION
Sometimes we use `set -u` with empty arrays, which breaks in bash < 4.4.
E.g. for storing [trace_option](https://github.com/returntocorp/ocaml-tree-sitter-core/blob/main/scripts/ocaml-tree-sitter-gen-ocaml#L77) in scripts/ocaml-tree-sitter-gen-ocaml.