### PR TITLE
Free tree-sitter tree when done

### DIFF
--- a/src/bindings/lib/Tree_sitter_API.ml
+++ b/src/bindings/lib/Tree_sitter_API.ml
@@ -49,7 +49,14 @@ module Tree = struct
   external edit : ts_tree -> int -> int -> int -> int -> int -> int -> ts_tree
     = "octs_tree_edit_bytecode" "octs_tree_edit_native"
 
-  external delete : ts_tree -> unit = "octs_tree_delete"
+  (* This exposes ts_tree_delete, the C function to free
+     the tree-sitter tree. We call this manually as a hack
+     because the OCaml garbage collector is not aware of
+     the tree. Ideally, we would instead give the garbage
+     collector the information it needed about the tree. 
+     Currently this function is used solely in of_ts_tree
+     in Tree_sitter_output *)
+    external delete : ts_tree -> unit = "octs_tree_delete"
 end
 
 module Point = struct

--- a/src/bindings/lib/Tree_sitter_API.ml
+++ b/src/bindings/lib/Tree_sitter_API.ml
@@ -53,10 +53,10 @@ module Tree = struct
      the tree-sitter tree. We call this manually as a hack
      because the OCaml garbage collector is not aware of
      the tree. Ideally, we would instead give the garbage
-     collector the information it needed about the tree. 
+     collector the information it needed about the tree.
      Currently this function is used solely in of_ts_tree
      in Tree_sitter_output *)
-    external delete : ts_tree -> unit = "octs_tree_delete"
+  external delete : ts_tree -> unit = "octs_tree_delete"
 end
 
 module Point = struct

--- a/src/bindings/lib/Tree_sitter_API.ml
+++ b/src/bindings/lib/Tree_sitter_API.ml
@@ -48,6 +48,8 @@ module Tree = struct
 
   external edit : ts_tree -> int -> int -> int -> int -> int -> int -> ts_tree
     = "octs_tree_edit_bytecode" "octs_tree_edit_native"
+
+  external delete : ts_tree -> unit = "octs_tree_delete"
 end
 
 module Point = struct

--- a/src/bindings/lib/Tree_sitter_output.ml
+++ b/src/bindings/lib/Tree_sitter_output.ml
@@ -49,8 +49,8 @@ let of_ts_tree ts_tree =
     !counter
   in
   let res = of_ts_node get_node_id root in
-  (* This manually frees the tree. Do not use the tree in any 
-     way after this. If this is changed, also update the comment 
+  (* This manually frees the tree. Do not use the tree in any
+     way after this. If this is changed, also update the comment
      in Tree_sitter_API *)
   Tree.delete ts_tree;
   res

--- a/src/bindings/lib/Tree_sitter_output.ml
+++ b/src/bindings/lib/Tree_sitter_output.ml
@@ -48,7 +48,9 @@ let of_ts_tree ts_tree =
     incr counter;
     !counter
   in
-  of_ts_node get_node_id root
+  let res = of_ts_node get_node_id root in
+  Tree.delete ts_tree;
+  res
 
 let to_json ?(pretty = false) node =
   let compact_json = Tree_sitter_output_j.string_of_node node in

--- a/src/bindings/lib/Tree_sitter_output.ml
+++ b/src/bindings/lib/Tree_sitter_output.ml
@@ -49,6 +49,9 @@ let of_ts_tree ts_tree =
     !counter
   in
   let res = of_ts_node get_node_id root in
+  (* This manually frees the tree. Do not use the tree in any 
+     way after this. If this is changed, also update the comment 
+     in Tree_sitter_API *)
   Tree.delete ts_tree;
   res
 

--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -48,7 +48,7 @@ static void finalize_tree(value v) {
   // However, finalize_tree is called before we are done with the
   // underlying tree. Therefore, instead we moved this code to
   // octs_tree_delete, which we expose in Tree_sitter_API as the
-  // delete function for Tree. 
+  // delete function for Tree.
 }
 
 static struct custom_operations tree_custom_ops = {

--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -40,13 +40,7 @@ typedef struct _tree {
 } tree_W;
 
 static void finalize_tree(value v) {
-  tree_W *p;
-  p = (tree_W *)Data_custom_val(v);
-  //TODO: ts_tree_delete(p->tree);
-  // this caused some segfaults, probably during Gc after
-  // analyzing many Ruby files. We go around this bug by
-  // running the Ruby parser in a separate process so segfaults
-  // or here memory leak do not reach the main semgrep-core process.
+  // TODO I assume we can then delete this function? But pushing to github first
 }
 
 static struct custom_operations tree_custom_ops = {
@@ -133,6 +127,15 @@ CAMLprim value octs_parser_parse_string(value vParser, value vSource) {
 
   CAMLreturn(v);
 };
+
+void octs_tree_delete(value vTree) {
+  CAMLparam1(vTree);
+
+  tree_W *t = (tree_W *)Data_custom_val(vTree);
+  ts_tree_delete(t->tree);
+
+  CAMLreturn0;
+}
 
 CAMLprim value octs_tree_root_node(value vTree) {
   CAMLparam1(vTree);

--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -40,7 +40,15 @@ typedef struct _tree {
 } tree_W;
 
 static void finalize_tree(value v) {
-  // TODO I assume we can then delete this function? But pushing to github first
+  // Originally, we freed the free when we finalized it by doing:
+
+  // tree_W *t = (tree_W *)Data_custom_val(vTree);
+  // ts_tree_delete(t->tree);
+
+  // However, finalize_tree is called before we are done with the
+  // underlying tree. Therefore, instead we moved this code to
+  // octs_tree_delete, which we expose in Tree_sitter_API as the
+  // delete function for Tree. 
 }
 
 static struct custom_operations tree_custom_ops = {


### PR DESCRIPTION
Expose ts_tree_delete and call it when done parsing (at the end of `of_ts_tree`)

Test plan:

Create a yaml file with pattern `$X == $Y`. Uncomment `ts_tree_delete` in `finalize_tree` in `semgrep-core/src/ocaml-tree-sitter-core/src/bindings/lib/bindings.c`.

Now go to `perf/bench/njs-juice` (or really any bench)

Run

```
sc -config /Users/emma/workspace/segfault/metavar.yaml .  -lang js
```

You should get a segfault.

Checkout this branch

There should be no segfault! You can confirm that the tree is being deleted by printing in `octs_tree_delete`. I don't know how to verify there's no memory leak :(