### PR TITLE
Fix function to read from file that's actually a named pipe

### DIFF
--- a/src/run/lib/Tree_sitter_parsing.ml
+++ b/src/run/lib/Tree_sitter_parsing.ml
@@ -40,15 +40,6 @@ let load_json_file ~src_file ~json_file =
   let src = Src_file.load_file src_file in
   { src; root }
 
-let string_of_file file =
-  let len = (Unix.stat file).Unix.st_size in
-  let ic = open_in_bin file in
-  Fun.protect
-    ~finally:(fun () -> close_in ic)
-    (fun () ->
-       really_input_string ic len
-    )
-
 let parse_source_string ?src_file ts_parser src_data =
   let src = Src_file.load_string ?src_file src_data in
   let root =
@@ -58,7 +49,7 @@ let parse_source_string ?src_file ts_parser src_data =
   { src; root }
 
 let parse_source_file ts_parser src_file =
-  let src_data = string_of_file src_file in
+  let src_data = Util_file.read_file src_file in
   parse_source_string ~src_file ts_parser src_data
 
 let print src =

--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -1,0 +1,41 @@
+(*
+   Generic utilities not provided by OCaml.
+*)
+
+(*
+   [copied from pfff/commons/Common.ml]
+
+   This implementation works even with Linux files like /dev/fd/63
+   created by bash's process substitution e.g.
+
+     my-ocaml-program <(echo contents)
+
+   See https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
+
+   In bash, '<(echo contents)' is replaced by something like
+   '/dev/fd/63' which is a special file of apparent size 0 (as
+   reported by `Unix.stat`) but contains data (here,
+   "contents\n"). So we can't use 'Unix.stat' or 'in_channel_length'
+   to obtain the length of the file contents. Instead, we read the file
+   chunk by chunk until there's nothing left to read.
+
+   Why such a function is not provided by the ocaml standard library is
+   unclear.
+*)
+let read_file path =
+  let buf_len = 4096 in
+  let extbuf = Buffer.create 4096 in
+  let buf = Bytes.create buf_len in
+  let rec loop fd =
+    match Unix.read fd buf 0 buf_len with
+    | 0 -> Buffer.contents extbuf
+    | num_bytes ->
+        assert (num_bytes > 0);
+        assert (num_bytes <= buf_len);
+        Buffer.add_subbytes extbuf buf 0 num_bytes;
+        loop fd
+  in
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> loop fd)

--- a/src/run/lib/Util_file.mli
+++ b/src/run/lib/Util_file.mli
@@ -1,0 +1,14 @@
+(*
+   Generic file utilities not provided by OCaml.
+*)
+
+(* Read the contents of file.
+
+   This implementation works even with Linux files like /dev/fd/63
+   created by bash when using "process substitution"* e.g.
+
+     my-ocaml-program <(echo contents)
+
+   * https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
+*)
+val read_file : string -> string

--- a/test/seq/check-test-output
+++ b/test/seq/check-test-output
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Extra tests.
+#
+
+# Check that bash process substitution works.
+# The following should parse without an error.
+# Should be the same as just:
+#   ./parse test/ok/ex1
+#
+./parse <(cat test/ok/ex1)


### PR DESCRIPTION
This allows support for process substitution on the command line of a program that passes the file to an ocaml-tree-sitter parser. E.g. the following now works:
```bash
$ ./parse <(echo 'print("hello");')
```

### Security

- [ ] Change has security implications (if so, ping the security team)
