### PR TITLE
Remove bin symlink if present (left over from old setup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PROJECT_ROOT = $(shell pwd)
 .PHONY: build
 build:
 	dune build
-	test -d bin || mkdir bin
+	test -d bin || { rm -f bin && mkdir bin; }
 	ln -sf ../_build/install/default/bin/ocaml-tree-sitter \
 	  bin/ocaml-tree-sitter
 


### PR DESCRIPTION
tested locally - best effort for easier migration

### Security

- [x] Change has no security implications (otherwise, ping the security team)
