### PR TITLE
Fix license field in opam file

### DIFF
--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "martin@returntocorp.com"
+maintainer: "martin@r2c.dev"
 authors: ["r2c"]
 homepage: "https://github.com/returntocorp/ocaml-tree-sitter"
 bug-reports: "https://github.com/returntocorp/ocaml-tree-sitter/issues"
 dev-repo: "git+https://github.com/returntocorp/ocaml-tree-sitter.git"
-license: "BSD-3-Clause"
+license: "GPL-3.0-only"
 
 build: [
   ["./configure"]


### PR DESCRIPTION
License code name is from https://spdx.org/licenses/

Closes https://github.com/returntocorp/ocaml-tree-sitter-core/issues/15

### Security

- [x] Change has no security implications (otherwise, ping the security team)
