### PR TITLE
adding to aggregate parse errors

### DIFF
--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -8,6 +8,47 @@ import csv
 import json
 import sys
 
+STAT_PATH = "stat.tmp/"
+NUM_EXAMPLES = 3
+
+def add_to_code_lines(example_arr, file_name):
+    if len(example_arr) >= NUM_EXAMPLES:
+        return False
+
+    # check if the file name is in the example array
+    for example in example_arr:
+        if file_name in example:
+            return False
+
+    return True
+
+def get_code_lines(err):
+    split_file = err['file'].split('/')
+    if len(split_file) > 0:
+        complete_file_path = STAT_PATH + split_file[0] + '/' + err['file']
+    else:
+        complete_file_path = STAT_PATH + err['file']
+    with open(complete_file_path, 'r') as open_file:
+        content = open_file.readlines()
+        # get the surrounding lines
+        start_line = 0
+        end_line = 0
+        if err['start_pos']['row'] > 0:
+            start_line = err['start_pos']['row']-1
+        if err['end_pos']['row'] < len(content):
+            end_line = err['end_pos']['row']+1
+        return ''.join(content[start_line:end_line])
+
+def get_file_and_location(err):
+    file_and_location = (str(err['file']) +
+                    ': start -- ' +
+                    str(err['start_pos']['row']) + '; ' +
+                    str(err['start_pos']['column']) +
+                    '; end -- ' +
+                    str(err['end_pos']['row']) + '; ' +
+                    str(err['end_pos']['column']))
+    return file_and_location
+
 def parse_json_error_log():
     clusters = {}
     for line in sys.stdin:
@@ -19,19 +60,28 @@ def parse_json_error_log():
                     'error_class': key,
                     'num_errors': 0,
                     'num_lines': 0,
+                    'code_location': [],
+                    'code': [],
                 }
                 clusters[key] = clus
             clus = clusters[key]
             clus['num_errors'] = clus['num_errors'] + 1
             err_num_lines = err['end_pos']['row'] - err['start_pos']['row'] + 1
             clus['num_lines'] = clus['num_lines'] + err_num_lines
+
+            if add_to_code_lines(clus['code_location'], err['file']):
+                clus['code_location'].append(get_file_and_location(err))
+                clus['code'].append(get_code_lines(err))
+
     return clusters
 
-
 def print_csv_clusters(clusters):
-    for key, clus in sorted(clusters.items(), key = lambda c: c[1]['num_errors']):
-        writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
-        row = [clus['num_errors'], clus['num_lines'], clus['error_class']]
+    writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(['num errors', 'num lines', 'error class', 'code_location', 'code'])
+    for _key, clus in sorted(clusters.items(), key = lambda c: -c[1]['num_errors']):
+        code_locs_to_string = ';\n'.join(clus['code_location'])
+        all_code_lines = ';\n'.join(clus['code'])
+        row = [clus['num_errors'], clus['num_lines'], clus['error_class'], code_locs_to_string, all_code_lines]
         writer.writerow(row)
 
 
@@ -41,4 +91,3 @@ if __name__ == "__main__":
         print_csv_clusters(clusters)
     else:
         print("reads records from a parse-error.json file on stdin")
-        sys.exit(1)

--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -7,6 +7,7 @@
 import csv
 import json
 import sys
+import argparse
 
 STAT_PATH = "stat.tmp/"
 NUM_EXAMPLES = 3
@@ -87,7 +88,8 @@ def print_csv_clusters(clusters):
 
 if __name__ == "__main__":
     if len(sys.argv) == 1:
-        clusters = parse_json_error_log()
-        print_csv_clusters(clusters)
+            clusters = parse_json_error_log()
+            print_csv_clusters(clusters)
     else:
         print("reads records from a parse-error.json file on stdin")
+        sys.exit(1)

--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -12,6 +12,11 @@ import argparse
 STAT_PATH = "stat.tmp/"
 NUM_EXAMPLES = 3
 
+'''
+Returns whether we should add another code example --
+we should return if there are less than the number of examples we want
+and the file name given actually exists.
+'''
 def add_to_code_lines(example_arr, file_name):
     if len(example_arr) >= NUM_EXAMPLES:
         return False
@@ -24,6 +29,7 @@ def add_to_code_lines(example_arr, file_name):
     return True
 
 def get_code_lines(err):
+    # get the complete file path of the file from err array
     split_file = err['file'].split('/')
     if len(split_file) > 0:
         complete_file_path = STAT_PATH + split_file[0] + '/' + err['file']
@@ -40,6 +46,10 @@ def get_code_lines(err):
             end_line = err['end_pos']['row']+1
         return ''.join(content[start_line:end_line])
 
+'''
+Returns the specific file name and line numbers that the error
+started and ended on.
+'''
 def get_file_and_location(err):
     file_and_location = (str(err['file']) +
                     ': start -- ' +
@@ -88,8 +98,8 @@ def print_csv_clusters(clusters):
 
 if __name__ == "__main__":
     if len(sys.argv) == 1:
-            clusters = parse_json_error_log()
-            print_csv_clusters(clusters)
+        clusters = parse_json_error_log()
+        print_csv_clusters(clusters)
     else:
         print("reads records from a parse-error.json file on stdin")
         sys.exit(1)


### PR DESCRIPTION
Now, the script outputs a CSV with: 

* three file names and line numbers where the error occurs
* three example portions of code where the error occurs. 

_To use:_
To use the script by itself, run with:
`cd lang/<lang testing>`
`cat stat/parse-error.json | python ../../scripts/aggregate-parse-errors.py > outputfile.csv`

To use the script as part of `make stat`, run:
`cd lang/<lang testing>`
`make stat` 
and the script will output the csv in the `stat/` folder. 

Here's a few lines of the csv:
```
num errors,num lines,error class,code_location,code
114,114,"parent: infix_expression, left sibling: expression, first child: ""=""","KotlinMvp/app/src/main/java/com/hazz/kotlinmvp/ui/adapter/CategoryAdapter.kt: start -- 48; 65; end -- 48; 66;
KotlinMvp/app/src/main/java/com/hazz/kotlinmvp/view/recyclerview/ViewHolder.kt: start -- 104; 41; end -- 104; 42;
kotlinx.coroutines/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt: start -- 42; 26; end -- 42; 27","        //设置方正兰亭细黑简体
        holder.getView<TextView>(R.id.tv_category_name).typeface = textTypeface
;
    fun setViewVisibility(viewId: Int, visibility: Int): ViewHolder {
        getView<View>(viewId).visibility = visibility
;
     *   withContext(Dispatchers.Main.immediate) {
```