### PR TITLE
Catch UTF-8 errors in python script

### DIFF
--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -36,7 +36,11 @@ def get_code_lines(err):
     else:
         complete_file_path = STAT_PATH + err['file']
     with open(complete_file_path, 'r') as open_file:
-        content = open_file.readlines()
+        try:
+            content = open_file.readlines()
+        except UnicodeDecodeError:
+            print(f"Broken UTF-8 in file {complete_file_path}", file=sys.stderr)
+            content = []
         # get the surrounding lines
         start_line = 0
         end_line = 0


### PR DESCRIPTION
The error was:
```
roslyn/src/Workspaces/TestSourceGenerator/HelloWorldGenerator.cs (45 lines)  OK
Traceback (most recent call last):
  File "/home/user/ocaml-tree-sitter/scripts/aggregate-parse-errors", line 101, in <module>
    clusters = parse_json_error_log()
  File "/home/user/ocaml-tree-sitter/scripts/aggregate-parse-errors", line 85, in parse_json_error_log
    clus['code'].append(get_code_lines(err))
  File "/home/user/ocaml-tree-sitter/scripts/aggregate-parse-errors", line 39, in get_code_lines
    content = open_file.readlines()
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x83 in position 43: invalid start byte
```

(https://app.circleci.com/pipelines/github/returntocorp/ocaml-tree-sitter-semgrep/1181/workflows/1c1b98a1-bb12-4677-b6dc-60cd80f0a222/jobs/1221)

### Security

- [x] Change has no security implications (otherwise, ping the security team)
