### PR TITLE
Suppress the deprecation alerts from cmdliner >= 1.1.0

### DIFF
--- a/src/gen/bin/Ocaml_tree_sitter_main.ml
+++ b/src/gen/bin/Ocaml_tree_sitter_main.ml
@@ -1,6 +1,10 @@
 (*
    Application's entrypoint.
 *)
+
+(* for cmdliner >= 1.1.0 *)
+[@@@alert "-deprecated"]
+
 open Printf
 open Cmdliner
 open Tree_sitter_gen

--- a/src/run/lib/Main.ml
+++ b/src/run/lib/Main.ml
@@ -3,6 +3,9 @@
    parsers.
 *)
 
+(* for cmdliner >= 1.1.0 *)
+[@@@alert "-deprecated"]
+
 open Printf
 open Cmdliner
 open Tree_sitter_bindings


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
