### PR TITLE
Update opam package to tolerate any version of cmdliner

### DIFF
--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -17,7 +17,7 @@ depends: [
   "alcotest"
   "ANSITerminal"
   "atdgen"
-  "cmdliner" {= "1.0.4"}
+  "cmdliner"
   "conf-pkg-config"
   "dune" {>= "2.1"}
   "ocaml"


### PR DESCRIPTION
Both versions of cmdliner (1.0.x or 1.1.x) are fine since #28. We're about to require 1.1.x in semgrep. This fixes the opam file, which we use to install dependencies in the semgrep project (with `opam install --deps-only *.opam`).

### Security

- [x] Change has no security implications (otherwise, ping the security team)
