### PR TITLE
Add missing newlines in multiline tokens

### DIFF
--- a/src/run/lib/Loc.mli
+++ b/src/run/lib/Loc.mli
@@ -3,12 +3,12 @@
 *)
 
 type pos = Tree_sitter_bindings.Tree_sitter_output_t.position = {
-  row : int;
-  column : int;
+  row : int; (* 0-based *)
+  column : int; (* 0-based *)
 }
 
 (* TODO: include filename as a field? *)
 type t = {
-  start: pos;
-  end_: pos;
+  start: pos; (* inclusive *)
+  end_: pos; (* exclusive i.e. start = end_ gives the empty string. *)
 }

--- a/src/run/lib/Src_file.ml
+++ b/src/run/lib/Src_file.ml
@@ -21,13 +21,28 @@ let info x = x.info
 
 let get_num_lines x = Array.length x.lines
 
+let split_after_newline s =
+  let rec split acc start pos =
+    if pos < String.length s then
+      match s.[pos] with
+      | '\n' ->
+          let new_start = pos + 1 in
+          let acc = String.sub s start (new_start - start) :: acc in
+          split acc new_start new_start
+      | _ ->
+          split acc start (pos + 1)
+    else
+      String.sub s start (pos - start) :: acc |> List.rev
+  in
+  split [] 0 0
+
 let load_string ?(src_name = "<source>") ?src_file src_contents =
   let info =
     match src_file with
     | None -> { name = src_name; path = None }
     | Some path -> { name = path; path = Some path }
   in
-  let lines = String.split_on_char '\n' src_contents in
+  let lines = split_after_newline src_contents in
   {
     info;
     lines = Array.of_list lines;
@@ -104,10 +119,8 @@ let get_region x start end_ =
   else if first_row < last_row then
     let buf = Buffer.create 100 in
     safe_add_rest_of_line buf x first_row start.column;
-    Buffer.add_string buf "\n";
     for row = first_row + 1 to last_row - 1 do
-      safe_add_whole_line buf x row;
-      Buffer.add_string buf "\n";
+      safe_add_whole_line buf x row
     done;
     safe_add_beginning_of_line buf x last_row end_.column;
     Buffer.contents buf

--- a/src/run/lib/Src_file.ml
+++ b/src/run/lib/Src_file.ml
@@ -21,40 +21,6 @@ let info x = x.info
 
 let get_num_lines x = Array.length x.lines
 
-let with_in_channel filename f =
-  let ic = open_in filename in
-  let finally () = close_in_noerr ic in
-  try
-    let res = f ic in
-    finally ();
-    res
-  with e ->
-    finally ();
-    raise e
-
-let read_lines filename =
-  with_in_channel filename (fun ic ->
-    let acc = ref [] in
-    (try
-       while true do
-         acc := (input_line ic) :: !acc
-       done;
-       assert false
-     with End_of_file ->
-       ()
-    );
-    List.rev !acc
-  )
-
-let load_file src_file =
-  {
-    info = {
-      name = src_file;
-      path = Some src_file;
-    };
-    lines = Array.of_list (read_lines src_file);
-  }
-
 let load_string ?(src_name = "<source>") ?src_file src_contents =
   let info =
     match src_file with
@@ -66,6 +32,33 @@ let load_string ?(src_name = "<source>") ?src_file src_contents =
     info;
     lines = Array.of_list lines;
   }
+
+(*
+   Non-trivial function to read correctly from any kind of file,
+   including named pipes such as those created by bash via
+   "process substitution" e.g. echo <(echo hello)
+*)
+let read_file path =
+  let buf_len = 4096 in
+  let extbuf = Buffer.create 4096 in
+  let buf = Bytes.create buf_len in
+  let rec loop fd =
+    match Unix.read fd buf 0 buf_len with
+    | 0 -> Buffer.contents extbuf
+    | num_bytes ->
+        assert (num_bytes > 0);
+        assert (num_bytes <= buf_len);
+        Buffer.add_subbytes extbuf buf 0 num_bytes;
+        loop fd
+  in
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> loop fd)
+
+let load_file path =
+  let data = read_file path in
+  load_string ~src_name:path ~src_file:path data
 
 let safe_get_row x row =
   let lines = x.lines in

--- a/src/run/lib/Src_file.ml
+++ b/src/run/lib/Src_file.ml
@@ -111,8 +111,10 @@ let get_region x start end_ =
   else if first_row < last_row then
     let buf = Buffer.create 100 in
     safe_add_rest_of_line buf x first_row start.column;
+    Buffer.add_string buf "\n";
     for row = first_row + 1 to last_row - 1 do
-      safe_add_whole_line buf x row
+      safe_add_whole_line buf x row;
+      Buffer.add_string buf "\n";
     done;
     safe_add_beginning_of_line buf x last_row end_.column;
     Buffer.contents buf

--- a/src/run/lib/Src_file.mli
+++ b/src/run/lib/Src_file.mli
@@ -11,9 +11,12 @@ type info = {
 type t = private {
   info: info;
   (*
-     Lines represent the contents of the input split on '\n'.
-     If the input ends with '\n', then the last line is "".
+     Lines represent the contents of the input split after the line
+     terminator '\n'.
+     If the input ends with '\n', then the last line will be "" i.e.
+     all the lines are LF-terminated except the last one.
      The empty file contains one empty line.
+     Concatenating the strings in the array results in the original data.
   *)
   lines: string array;
 }

--- a/src/run/lib/Src_file.mli
+++ b/src/run/lib/Src_file.mli
@@ -10,6 +10,11 @@ type info = {
 
 type t = private {
   info: info;
+  (*
+     Lines represent the contents of the input split on '\n'.
+     If the input ends with '\n', then the last line is "".
+     The empty file contains one empty line.
+  *)
   lines: string array;
 }
 
@@ -35,6 +40,9 @@ val load_string : ?src_name:string -> ?src_file:string -> string -> t
 (*
    Return the substring corresponding to the specified region.
    It may or may not coincide with the boundaries of a token.
+
+   Arguments: start, end_ where end_ is the position of the first character
+   *after* the selection region.
 *)
 val get_region : t -> Loc.pos -> Loc.pos -> string
 

--- a/src/run/test/Src_file.ml
+++ b/src/run/test/Src_file.ml
@@ -32,10 +32,10 @@ let test_load_file () =
       (expected_lines = lines_from_file)
   in
   check [| "" |] "";
-  check [| ""; "" |] "\n";
-  check [| "a"; "" |] "a\n";
-  check [| "a"; "b\r"; "c" |] "a\nb\r\nc";
-  check [| "a\r"; "" |] "a\r\n"
+  check [| "\n"; "" |] "\n";
+  check [| "a\n"; "" |] "a\n";
+  check [| "a\n"; "b\r\n"; "c" |] "a\nb\r\nc";
+  check [| "a\r\n"; "" |] "a\r\n"
 
 let test_get_region () =
   let open Loc in

--- a/src/run/test/Src_file.ml
+++ b/src/run/test/Src_file.ml
@@ -1,0 +1,76 @@
+(*
+   Unit tests for the Src_file module
+*)
+
+open Printf
+open Tree_sitter_run
+
+(*
+   Check that the behavior wrt to newlines is correct and the same
+   whether we read from a file or from a string.
+*)
+let test_load_file () =
+  let load_file data =
+    let file, oc = Filename.open_temp_file "ocaml-tree-sitter-core-test" "" in
+    Fun.protect
+      (fun () ->
+         Fun.protect
+           (fun () ->
+              output_string oc data
+           )
+           ~finally:(fun () -> close_out_noerr oc);
+         Src_file.load_file file
+      )
+      ~finally:(fun () -> Sys.remove file)
+  in
+  let check expected_lines data =
+    let lines_from_string = (Src_file.load_string data).lines in
+    let lines_from_file = (load_file data).lines in
+    Alcotest.(check bool) (sprintf "from_string %S" data) true
+      (expected_lines = lines_from_string);
+    Alcotest.(check bool) (sprintf "from_file [%S]" data) true
+      (expected_lines = lines_from_file)
+  in
+  check [| "" |] "";
+  check [| ""; "" |] "\n";
+  check [| "a"; "" |] "a\n";
+  check [| "a"; "b\r"; "c" |] "a\nb\r\nc";
+  check [| "a\r"; "" |] "a\r\n"
+
+let test_get_region () =
+  let open Loc in
+  let input = "012\n45\r\n89\n" in
+  let src = Src_file.load_string input in
+  let pos0 = { row = 0; column = 0 } in
+  let pos1 = { row = 0; column = 1 } in
+  let _pos2 = { row = 0; column = 2 } in
+  let pos3 = { row = 0; column = 3 } in
+  let pos4 = { row = 1; column = 0 } in
+  let _pos5 = { row = 1; column = 1 } in
+  let pos6 = { row = 1; column = 2 } in
+  let pos7 = { row = 1; column = 3 } in
+  let pos8 = { row = 2; column = 0 } in
+  let pos9 = { row = 2; column = 1 } in
+  let pos10 = { row = 2; column = 2 } in
+  let pos11 = { row = 2; column = 3 } in
+  let pos12 = { row = 2; column = 3 } in
+  let check expected start end_ =
+    let actual = Src_file.get_region src start end_ in
+    Alcotest.(check string) (sprintf "equal %S" expected) expected actual
+  in
+  check "" pos0 pos0;
+  check "" pos1 pos0; (* invalid bounds *)
+  check "" pos11 pos12; (* invalid bounds *)
+  check "0" pos0 pos1;
+  check "12" pos1 pos3;
+  check "45" pos4 pos6;
+  check "45\r" pos4 pos7;
+  check "45\r\n8" pos4 pos9;
+  check "9" pos9 pos10;
+  check "9\n" pos9 pos11;
+  check "89\n" pos8 pos12 (* invalid bounds *)
+
+let test = "Src_file", [
+  "load_file", `Quick, test_load_file;
+  "get_region", `Quick, test_get_region;
+]

--- a/src/run/test/Src_file.ml
+++ b/src/run/test/Src_file.ml
@@ -46,7 +46,7 @@ let test_get_region () =
   let _pos2 = { row = 0; column = 2 } in
   let pos3 = { row = 0; column = 3 } in
   let pos4 = { row = 1; column = 0 } in
-  let _pos5 = { row = 1; column = 1 } in
+  let pos5 = { row = 1; column = 1 } in
   let pos6 = { row = 1; column = 2 } in
   let pos7 = { row = 1; column = 3 } in
   let pos8 = { row = 2; column = 0 } in
@@ -68,7 +68,10 @@ let test_get_region () =
   check "45\r\n8" pos4 pos9;
   check "9" pos9 pos10;
   check "9\n" pos9 pos11;
-  check "89\n" pos8 pos12 (* invalid bounds *)
+  check "89\n" pos8 pos12; (* invalid bounds *)
+  check "\n" pos3 pos4;
+  check "\n4" pos3 pos5;
+  check "\n45\r\n" pos3 pos8
 
 let test = "Src_file", [
   "load_file", `Quick, test_load_file;

--- a/src/run/test/test.ml
+++ b/src/run/test/test.ml
@@ -3,6 +3,7 @@
 *)
 
 let test_suites : unit Alcotest.test list = [
-  Util_string.test;
   Matcher.test;
+  Src_file.test;
+  Util_string.test;
 ]


### PR DESCRIPTION
test plan:
when used in semgrep, the multiline raw_text token
contained between the <script> tags in an HTML file now
contains newlines.

```
cat ~/test.html
<script>
   foo()
  bar()
  foo
</script>
[pad@thinkstation ~]$ yy -l html -dump_ast ~/test.html
+ /home/pad/yy/_build/default/src/cli/Main.exe -l html -dump_ast /home/pad/test.html
[0.021  Info       Main.Setup_logging   ] loaded log_config.json
[0.021  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -l html -dump_ast /home/pad/test.html
[0.021  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.85.0-21-g83dde33d4-dirty, pfff: 0.42
Pr(
  [ExprStmt(
     Xml(
       {xml_tag=XmlFragment((), ()); xml_attrs=[];
        xml_body=[XmlXml(
                    {xml_tag=XmlClassic((), ("script", ()), (), ()); xml_attrs=[
                     ]; xml_body=[XmlText(("foo()
  bar()
  foo
", ()))]; })];
        }), ())])
```
Before this PR, the newlines were not present in XmlText (which
then prevents to parse the code inside with metavariable-pattern:
language: JS


### Security

- [x] Change has no security implications (otherwise, ping the security team)