### PR TITLE
Update tree-sitter to v0.20.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tree-sitter-cli": "^0.19.4"
+    "tree-sitter-cli": "^0.20.6"
   }
 }

--- a/scripts/download-tree-sitter
+++ b/scripts/download-tree-sitter
@@ -9,7 +9,7 @@ prog_name=$(basename "$0")
 # The official version of tree-sitter we use for the code generator and
 # for the runtime library. Please try to keep this as the single source
 # of truth.
-default_version="0.19.4"
+default_version="0.20.6"
 
 error() {
   echo "Current directory: $(pwd)" >&2


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
