### PR TITLE
Allow specifying the headers for treesitter via the environment

### DIFF
--- a/scripts/ocaml-tree-sitter-gen-ocaml
+++ b/scripts/ocaml-tree-sitter-gen-ocaml
@@ -213,6 +213,7 @@ cat > "$dst_dir"/lib/dune <<EOF
     (names ${c_files})
     (flags -std=c99
            -fPIC
+           -I %{env:TREESITTER_INCDIR=/usr/local/include}
            -I .)
   )
 
@@ -227,6 +228,7 @@ cat > "$dst_dir"/lib/dune <<EOF
     (language cxx)
     (names ${cxx_files})
     (flags -fPIC
+           -I %{env:TREESITTER_INCDIR=/usr/local/include}
            -I .)
   )
 )


### PR DESCRIPTION
Similar to TREESITTER_LIBDIR, the headers for treesitter may be
installed in a non-standard location. semgrep's `make configure` will
correctly set the environment variables, but `dune build` wasn't
running cc with the right include paths, so `#include
<tree_sitter/api.h>` wasn't resolving

I tested this by applying this patch to all of the generated
submodules (using a Very Advanced sed script).

### Security

- [x] Change has no security implications (otherwise, ping the security team)
