### PR TITLE
Leave token() constructs in place and give them a name using alias()

### DIFF
--- a/src/gen/lib/CST_grammar.ml
+++ b/src/gen/lib/CST_grammar.ml
@@ -104,6 +104,8 @@ type rule_body =
   | Seq of rule_body list
   | Alias of ident * rule_body
   (* Alias (dummy rule name, anonymous rule)
+     Note that argument order in JS is reversed. It's alias(value, name)
+     rather than (name, value).
 
      This is used as a hack to work around pattern nodes (/.../)
      or token nodes (token(...)) that don't show up in the CST produced

--- a/src/gen/lib/CST_grammar_conv.ml
+++ b/src/gen/lib/CST_grammar_conv.ml
@@ -101,7 +101,7 @@ let translate_token opt_rule_name token_contents =
   match name_of_body opt_rule_name token_contents with
   | Some name -> Token { name; is_inlined = false; description = Token }
   | None ->
-      match Missing_node.token_produces_node token_contents with
+      match Missing_node.get_token_node_name token_contents with
       | Some (Literal cst) ->
           translate_constant opt_rule_name cst
       | Some (Name name) ->

--- a/src/gen/lib/Codegen_CST.ml
+++ b/src/gen/lib/Codegen_CST.ml
@@ -188,6 +188,8 @@ let format_token ~def_name (tok : token) =
 let rec format_body ?def_name body : E.t =
   match body with
   | Symbol ident
+  | Alias (ident, Token _) ->
+      Fmt.atom (trans ident ^ " (*tok*)")
   | Alias (ident, _) ->
       Fmt.atom (trans ident)
   | Token tok ->

--- a/src/gen/lib/Codegen_CST.ml
+++ b/src/gen/lib/Codegen_CST.ml
@@ -187,7 +187,8 @@ let format_token ~def_name (tok : token) =
 
 let rec format_body ?def_name body : E.t =
   match body with
-  | Symbol ident
+  | Symbol ident ->
+      Fmt.atom (trans ident)
   | Alias (ident, Token _) ->
       Fmt.atom (trans ident ^ " (*tok*)")
   | Alias (ident, _) ->

--- a/src/gen/lib/Missing_node.ml
+++ b/src/gen/lib/Missing_node.ml
@@ -89,7 +89,6 @@ let extract_rules add_translation rules =
     let name =
       add_translation ~orig_name:preferred_name ~preferred_name
     in
-    printf "add rule: preferred_name=%s, name=%s\n" preferred_name name;
     Hashtbl.replace new_rules name rule_body;
     name
   in

--- a/src/gen/lib/Missing_node.ml
+++ b/src/gen/lib/Missing_node.ml
@@ -1,7 +1,10 @@
 (*
-   Ensure that every pattern is at the root of a rule.
-   This a workaround for the fact that tree-sitter parsers don't produce
-   nodes matching patterns.
+   Ensure that the tree-sitter gives us a node in the CST for every node
+   in the grammar. Patterns (regexps) and token() constructs have no name
+   and tree-sitter will produce no node in the CST unless a name is
+   somehow assigned. We use the alias() construct to assign names to grammar
+   nodes that don't have one.
+
    See:
    - for patterns: https://github.com/tree-sitter/tree-sitter/issues/1151
    - for token(): https://github.com/tree-sitter/tree-sitter/issues/1156
@@ -19,12 +22,8 @@ let make_translator () =
   fun ~orig_name ~preferred_name ->
     Protect_ident.add_translation ~preferred_dst:preferred_name map orig_name
 
-(*
-   Will token(...) produce a node? If so, we don't need to extract it
-   and make it a separate rule.
-*)
-let token_produces_node (token_contents : rule_body) : token_node_name option =
-  let rec is_simple (x : rule_body) =
+let get_token_node_name (token_contents : rule_body) : token_node_name option =
+  let rec get (x : rule_body) =
     match x with
     | SYMBOL name -> Some (Name name)
     | STRING name -> Some (Literal name)
@@ -37,58 +36,27 @@ let token_produces_node (token_contents : rule_body) : token_node_name option =
     | REPEAT1 _ -> None
     | CHOICE _ -> None
     | SEQ _ -> None
-    | PREC (_prec, x) -> is_simple x
-    | PREC_DYNAMIC (_prec, x) -> is_simple x
-    | PREC_LEFT (_prec, x) -> is_simple x
-    | PREC_RIGHT (_prec, x) -> is_simple x
-    | ALIAS alias -> is_simple alias.content
-    | FIELD (_field_name, x) -> is_simple x
+    | PREC (_prec, x) -> get x
+    | PREC_DYNAMIC (_prec, x) -> get x
+    | PREC_LEFT (_prec, x) -> get x
+    | PREC_RIGHT (_prec, x) -> get x
+    | ALIAS alias -> get alias.content
+    | FIELD (_field_name, x) -> get x
   in
-  is_simple token_contents
+  get token_contents
 
-let should_extract_token token_contents =
-  let rec contains_prec (x : rule_body) =
-    match x with
-    | SYMBOL _
-    | STRING _
-    | BLANK
-    | PATTERN _ -> false
-
-    | IMMEDIATE_TOKEN x -> contains_prec x
-    | TOKEN x -> contains_prec x
-    | REPEAT x -> contains_prec x
-    | REPEAT1 x -> contains_prec x
-    | CHOICE xs -> List.exists contains_prec xs
-    | SEQ xs -> List.exists contains_prec xs
-    | PREC (_prec, _) -> true
-    | PREC_DYNAMIC (_prec, _) -> true
-    | PREC_LEFT (_prec, _) -> true
-    | PREC_RIGHT (_prec, _) -> true
-    | ALIAS alias -> contains_prec alias.content
-    | FIELD (_field_name, x) -> contains_prec x
-  in
-  token_produces_node token_contents = None
-  && not (contains_prec token_contents)
-
-let extract_pattern_rules_from_body add_rule body =
+let extract_alias_rules_from_body add_rule body =
   let rec extract (x : rule_body) =
     match x with
     | SYMBOL _
     | STRING _
     | BLANK -> x
 
-    | PATTERN _ as x ->
+    | PATTERN _
+    | IMMEDIATE_TOKEN _
+    | TOKEN _ as x ->
         let preferred_name = Type_name.name_ts_rule_body x in
         let name = add_rule preferred_name x in
-        (*
-           Hack to make the node appear in the CST due to bug
-           https://github.com/tree-sitter/tree-sitter/issues/1156
-           This allows keeping the rule inline, which is important to preserve
-           parsing behavior in some instances as was observed on the
-           PHP grammar:
-           https://github.com/returntocorp/ocaml-tree-sitter-core/issues/34
-           [simpler example needed]
-        *)
         ALIAS {
           value = name;
           named = true;
@@ -96,15 +64,6 @@ let extract_pattern_rules_from_body add_rule body =
           must_be_preserved = true;
         }
 
-    | IMMEDIATE_TOKEN _
-    | TOKEN _ as x ->
-        (* SYMBOLs (rule names like $.pat_123) are illegal within token()
-           (https://github.com/tree-sitter/tree-sitter/issues/1159),
-           so we leave any pattern that may be in there. It doesn't matter
-           since the point of token() is to get a single token.
-        *)
-        x
-
     | REPEAT x -> REPEAT (extract x)
     | REPEAT1 x -> REPEAT1 (extract x)
     | CHOICE xs -> CHOICE (List.map extract xs)
@@ -117,43 +76,7 @@ let extract_pattern_rules_from_body add_rule body =
     | FIELD (field_name, x) -> FIELD (field_name, extract x)
   in
   match body with
-  | PATTERN _pat as x ->
-      (* already at the root of a rule body, will have a name. *)
-      x
-  | x -> extract x
-
-let extract_token_rules_from_body add_rule body =
-  let rec extract (x : rule_body) =
-    match x with
-    | SYMBOL _
-    | STRING _
-    | BLANK -> x
-    | PATTERN _ as x -> x
-
-    | IMMEDIATE_TOKEN token_contents
-    | TOKEN token_contents as x ->
-        if should_extract_token token_contents then
-          let preferred_name = Type_name.name_ts_rule_body x in
-          let name = add_rule preferred_name x in
-          SYMBOL name
-        else
-          (* ok, we keep it. It will produce a node or it won't. We'll need
-             to re-analyze this when generating the code that consumes
-             the tree. *)
-          x
-
-    | REPEAT x -> REPEAT (extract x)
-    | REPEAT1 x -> REPEAT1 (extract x)
-    | CHOICE xs -> CHOICE (List.map extract xs)
-    | SEQ xs -> SEQ (List.map extract xs)
-    | PREC (prec, x) -> PREC (prec, extract x)
-    | PREC_DYNAMIC (prec, x) -> PREC_DYNAMIC (prec, extract x)
-    | PREC_LEFT (prec, x) -> PREC_LEFT (prec, extract x)
-    | PREC_RIGHT (prec, x) -> PREC_RIGHT (prec, extract x)
-    | ALIAS alias -> ALIAS { alias with content = extract alias.content }
-    | FIELD (field_name, x) -> FIELD (field_name, extract x)
-  in
-  match body with
+  | PATTERN _
   | IMMEDIATE_TOKEN _
   | TOKEN _ as x ->
       (* already at the root of a rule body, will have a name. *)
@@ -166,13 +89,13 @@ let extract_rules add_translation rules =
     let name =
       add_translation ~orig_name:preferred_name ~preferred_name
     in
+    printf "add rule: preferred_name=%s, name=%s\n" preferred_name name;
     Hashtbl.replace new_rules name rule_body;
     name
   in
   let rewritten_rules =
     List.map (fun (name, body) ->
-      let body = extract_pattern_rules_from_body add_rule body in
-      let body = extract_token_rules_from_body add_rule body in
+      let body = extract_alias_rules_from_body add_rule body in
       (name, body)
     ) rules
   in

--- a/src/gen/lib/Missing_node.mli
+++ b/src/gen/lib/Missing_node.mli
@@ -1,5 +1,5 @@
 (*
-   Add grammar rules to ensure that no pattern remains anonymous.
+   Add grammar rules to ensure that no pattern or token() remains anonymous.
 
    The problem is that tree-sitter won't return a node if the pattern
    doesn't have a name. A rule consisting only of a pattern such as
@@ -16,12 +16,5 @@ type token_node_name =
   | Literal of string
   | Name of string
 
-(*
-   Some token() constructs known to produce no node must be left in place
-   due to containing precedence annotations. This function is meant
-   for steps that consume the CST and need to know whether a node should
-   be expected.
-
-   The name of the node is returned iff a node will exist.
-*)
-val token_produces_node : Tree_sitter_t.rule_body -> token_node_name option
+(* Get the name of the token node as it will appear in the CST. *)
+val get_token_node_name : Tree_sitter_t.rule_body -> token_node_name option

--- a/src/gen/lib/Simplify_grammar.ml
+++ b/src/gen/lib/Simplify_grammar.ml
@@ -54,9 +54,15 @@ let simplify_rule_body translate_name =
     | PREC_LEFT (prec, x) -> PREC_LEFT (prec, simplify x)
     | PREC_RIGHT (prec, x) -> PREC_RIGHT (prec, simplify x)
     | ALIAS alias ->
+        let name =
+          if alias.named then
+            translate_name alias.value
+          else
+            alias.value
+        in
         let content = simplify alias.content in
         if alias.must_be_preserved then
-          ALIAS { alias with content }
+          ALIAS { alias with value = name; content }
         else
           content
     | FIELD (field_name, x) -> FIELD (field_name, simplify x)

--- a/src/gen/lib/Topo_sort.ml
+++ b/src/gen/lib/Topo_sort.ml
@@ -32,7 +32,7 @@ let extract_rule_deps (rule : rule) =
    The input is presorted so as to make the output insensitive to
    the input order.
 *)
-let tsort get_deps elts =
+let tsort ~show_id ~get_deps elts =
   let deps_data =
     List.map (fun elt ->
       let id, deps = get_deps elt in
@@ -50,7 +50,9 @@ let tsort get_deps elts =
     List.map (fun id ->
       let _id, _deps, self_dep, elt =
         try Hashtbl.find tbl id
-        with Not_found -> invalid_arg "tsort: found some unknown dependencies"
+        with Not_found ->
+          invalid_arg (sprintf "tsort: found an unknown dependency: %s"
+                         (show_id id))
       in
       (self_dep, elt)
     ) group
@@ -64,4 +66,4 @@ let tsort get_deps elts =
    - substituting the sorted names with the rules
 *)
 let sort rules =
-  tsort extract_rule_deps rules
+  tsort ~show_id:(fun s -> s) ~get_deps:extract_rule_deps rules

--- a/src/run/lib/Tree_sitter_dump.ml
+++ b/src/run/lib/Tree_sitter_dump.ml
@@ -22,7 +22,7 @@ let to_buf buf nodes =
     List.iter (print_node indent) nodes
   and print_node indent node =
     match node.children with
-    | None ->
+    | None | Some [] ->
         bprintf buf "%s%s\n" indent (string_of_node_kind node.kind);
     | Some children ->
         bprintf buf "%s%s:\n" indent (string_of_node_kind node.kind);

--- a/test/inline-token/check-test-output
+++ b/test/inline-token/check-test-output
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 #
-# Check the parsing output.
+# Check that the parsing output contains no Blank nodes.
 #
 set -eu -o pipefail
 
@@ -16,32 +16,10 @@ error() {
   exit 1
 }
 
-# token() constructs fall into 3 categories:
-# - extracted into their own named rule
-# - left in place and resulting in a node in the CST
-# - left in place and resulting in a missing node in the CST -> Blank
-#
-# Consult src/grammar.json to see the actual grammar after the simplify-grammar
-# pass.
-#
-expect_node="hello f g h i l s t u v field1"
-expect_missing_node="j w"
-expect_new_rule="goodbye a k mm n x y z field2"
-
-for x in $expect_node; do
-  echo "$x: Check parsing output. Expect simple node for the token."
-  out=test.out/ok/$x.cst
-  grep -q '"'"$x"'"' "$out" || error "$out" "Unexpected output in $out"
-done
-
-for x in $expect_missing_node; do
-  echo "$x: Check parsing output. Expect missing node for the token."
-  out=test.out/ok/$x.cst
-  grep -q "Blank" "$out" || error "$out" "Unexpected output in $out"
-done
-
-for x in $expect_new_rule; do
-  echo "$x: Check parsing output. Expect named rule for the token."
-  out=test.out/ok/$x.cst
-  grep -q "tok_" "$out" || error "$out" "Unexpected output in $out"
+for out in test.out/ok/* ; do
+  x=$(basename "$out")
+  echo "$x: Check that the output doesn't contain any Blank node."
+  if grep -q "Blank" "$out"; then
+    error "$out" "Unexpected Blank in $out"
+  fi
 done


### PR DESCRIPTION
We now leave all the `token()` constructs inline and use `alias()` to give them a name so as to obtain a node in the CST. This solution is similar to what we already use for patterns (regexps) which also would not show in the CST unless they have a name.

The previous solution was causing parsing conflicts in some instances.

Fixes #38 
Closes https://github.com/returntocorp/semgrep/issues/5374

### Security

- [x] Change has no security implications (otherwise, ping the security team)
