### PR TITLE
fix: Strip trailing spaces in pkg-config output

### DIFF
--- a/scripts/configure-tree-sitter
+++ b/scripts/configure-tree-sitter
@@ -22,8 +22,14 @@ Consider installing it with './scripts/install-tree-sitter-lib'."
 
 if [[ -z "${TREESITTER_INCDIR+x}" ]]; then
   TREESITTER_INCDIR=$(
+    # Strip the `-I` at the beginning, plus a single trailing space (if present)
+    # to get the path. pkgconf, which ships on RedHat and RedHat derived systems
+    # as a replacement for pkg-config, includes a trailing space in the flag,
+    # whereas pkg-config does not. This trailing space can lead to issues
+    # downstream.
     pkg-config --cflags-only-I tree-sitter \
-    | sed -e 's/^-I//'
+    | sed -e 's/^-I//' \
+    | sed -e 's/ $//'
   )
 fi
 export TREESITTER_INCDIR
@@ -31,7 +37,8 @@ export TREESITTER_INCDIR
 if [[ -z "${TREESITTER_LIBDIR+x}" ]]; then
   TREESITTER_LIBDIR=$(
     pkg-config --libs-only-L tree-sitter \
-    | sed -e 's/^-L//'
+    | sed -e 's/^-L//' \
+    | sed -e 's/ $//'
   )
 fi
 export TREESITTER_LIBDIR


### PR DESCRIPTION
On Fedora 36, pkgconf (https://github.com/pkgconf/pkgconf) ships as a
replacement for pkg-config. pkg-config does not include a trailing space
in the `--cflags-only-I` and `--libs-only-I` output, whereas pkgconf
does. This leads to linking errors when running `make test`:
https://gist.github.com/nmote/eb42fb763352f3980634763b38da9011

This PR works around the issue by stripping a trailing space from the
end of the `pkg-config` output, if it is present. This fixes the issue
on Fedora. I don't believe this will cause any issues on macOS, but I
don't have a way to test it.

Test plan:

```
$ ./configure
$ make test
```

### Security

- [x] Change has no security implications (otherwise, ping the security team)
