### PR TITLE
Improve workaround for tree-sitter aliased extras bug

### DIFF
--- a/test/implicit-extra/grammar-rev.js.expected
+++ b/test/implicit-extra/grammar-rev.js.expected
@@ -18,14 +18,6 @@ module.exports = grammar({
   ],
   rules: {
     program: $ => $.foos,
-    dummy_alias0_: $ => alias(
-      $.period,
-      $.period
-    ),
-    dummy_alias1: $ => alias(
-      $.comma,
-      $.comma
-    ),
     foos: $ => seq(
       $.foo,
       repeat(
@@ -52,6 +44,8 @@ module.exports = grammar({
     comma_explicit: $ => "unused",
     dummy_alias0: $ => "unused",
     period_explicit: $ => "" /* blank */,
-    comma_explicit_: $ => "" /* blank */
+    comma_explicit_: $ => "" /* blank */,
+    dummy_alias0_: $ => $.period,
+    dummy_alias1: $ => $.comma
   }
 });


### PR DESCRIPTION
This improves the workaround for
https://github.com/tree-sitter/tree-sitter/issues/1834 based on a better
understanding of the mechanism at play, which I gained by working on
https://github.com/tree-sitter/tree-sitter/pull/1836.

The issue is that tree-sitter chooses a "default alias" to use in place
of any rule that never appears unaliased. If a rule has multiple
aliases, tree-sitter chooses it based on the number of occurrences, and
if tied, it chooses the first one to appear in the grammar. Because of
this, the existing workaround could be stymied if an extra were to
appear in multiple rules, since then the alias added as part of this
workaround would be outnumbered by the aliases used to distinguish
extras from ordinary CST nodes.

Fortunately, a simple solution exists. If a rule appears unaliased
anywhere in the grammar, it's not given a default alias. So, this
improved workaround simply inserts unused rules that directly reference
each extra which also appears in another rule. Unlike the previous
workaround, the position of these rules does not matter, so we can
insert them at the end. This also removes the limitation that would have
prevented the workaround from functioning if an extra is referenced
directly in the first rule.

Test plan: Automated tests

### Security

- [x] Change has no security implications (otherwise, ping the security team)
