### PR TITLE
Add a CODEOWNERS file to restrict who can approve pull requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Together with the correct GitHub project setting, this limits who can
+# approve pull requests.
+# It's also used by GitHub to suggest reviewers.
+
+# Default owners:
+# Program Analysis team at r2c
+* @returntocorp/pa


### PR DESCRIPTION
In branch settings, I enabled this:
![image](https://user-images.githubusercontent.com/343265/192071785-b50996bb-6c5d-4a86-9bf5-ab54c83a03f4.png)

I want to use this to require the PA team to approve pull requests rather than anyone within our organization. We should check that it works and then apply it to other repos managed by the PA team.

Read the documentation for the `CODEOWNERS` file at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

test plan (after merging):
1. create a dummy pull request
2. invite an r2c developer who's not an admin and not on the PA team to approve the pull request. They should not be able to.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
