### PR TITLE
Infer a good name for patterns that represent case-insensitive keywords

### DIFF
--- a/src/gen/lib/Pattern_name.mli
+++ b/src/gen/lib/Pattern_name.mli
@@ -1,0 +1,7 @@
+(*
+   Infer a good name for a pattern (regexp) when possible, such as
+   for case-insensitive keywords such as /[Ii][Ff]/.
+*)
+
+(* Return a lowercase, alphanumeric name from a regexp in JavaScript syntax. *)
+val infer : string -> string option

--- a/src/gen/lib/Pattern_name.mll
+++ b/src/gen/lib/Pattern_name.mll
@@ -1,0 +1,65 @@
+{
+  (* Only pure lists of Char are guaranteed to be parsed correctly
+     by our parser. *)
+  type element =
+    | Char of char (* lowercased ascii *)
+    | Other (* something that we couldn't parse *)
+
+  let deduplicate xs =
+    let tbl = Hashtbl.create 10 in
+    List.filter (fun x ->
+      if Hashtbl.mem tbl x then
+        false
+      else (
+        Hashtbl.add tbl x ();
+        true
+      )
+    ) xs
+
+  let normalize_char = function
+  | '-' -> '_'
+  | c -> Char.lowercase_ascii c
+
+  let lowercase_singleton_of_cset s =
+    let lowercase_chars =
+      String.to_seq s
+      |> List.of_seq
+      |> List.map normalize_char
+      |> deduplicate
+    in
+    match lowercase_chars with
+    | [] -> Other
+    | [c] -> Char c
+    | _ :: _ -> Other
+
+}
+
+rule sequence = parse
+| ['a'-'z' 'A'-'Z' '0'-'9' '_' '-'] as c {
+     let elt = Char (normalize_char c) in
+     elt :: sequence lexbuf
+   }
+| '[' (['a'-'z' 'A'-'Z' '_' '-']+ as set) ']' {
+     let elt = lowercase_singleton_of_cset set in
+     elt :: sequence lexbuf
+   }
+| _ { Other :: sequence lexbuf }
+| eof { [] }
+
+{
+  let string_of_list xs =
+    List.map (String.make 1) xs |> String.concat ""
+
+  let infer s =
+    let lexbuf = Lexing.from_string s in
+    let elements = sequence lexbuf in
+    let chars =
+      try Some (List.map (function Char c -> c | Other -> raise Exit) elements)
+      with Exit -> None
+    in
+    match chars with
+    | Some chars ->
+        let chars = List.map (function '-' -> '_' | c -> c) chars in
+        Some (string_of_list chars)
+    | None -> None
+}

--- a/src/gen/lib/Pattern_name.mll
+++ b/src/gen/lib/Pattern_name.mll
@@ -20,14 +20,14 @@
   | '-' -> '_'
   | c -> Char.lowercase_ascii c
 
-  let lowercase_singleton_of_cset s =
-    let lowercase_chars =
+  let normalized_singleton_of_cset s =
+    let normalized_chars =
       String.to_seq s
       |> List.of_seq
       |> List.map normalize_char
       |> deduplicate
     in
-    match lowercase_chars with
+    match normalized_chars with
     | [] -> Other
     | [c] -> Char c
     | _ :: _ -> Other
@@ -40,7 +40,7 @@ rule sequence = parse
      elt :: sequence lexbuf
    }
 | '[' (['a'-'z' 'A'-'Z' '0'-'9' '_' '-']+ as set) ']' {
-     let elt = lowercase_singleton_of_cset set in
+     let elt = normalized_singleton_of_cset set in
      elt :: sequence lexbuf
    }
 | _ { Other :: sequence lexbuf }
@@ -58,8 +58,6 @@ rule sequence = parse
       with Exit -> None
     in
     match chars with
-    | Some chars ->
-        let chars = List.map (function '-' -> '_' | c -> c) chars in
-        Some (string_of_list chars)
+    | Some chars -> Some (string_of_list chars)
     | None -> None
 }

--- a/src/gen/lib/Pattern_name.mll
+++ b/src/gen/lib/Pattern_name.mll
@@ -39,7 +39,7 @@ rule sequence = parse
      let elt = Char (normalize_char c) in
      elt :: sequence lexbuf
    }
-| '[' (['a'-'z' 'A'-'Z' '_' '-']+ as set) ']' {
+| '[' (['a'-'z' 'A'-'Z' '0'-'9' '_' '-']+ as set) ']' {
      let elt = lowercase_singleton_of_cset set in
      elt :: sequence lexbuf
    }

--- a/src/gen/lib/Protect_ident.mli
+++ b/src/gen/lib/Protect_ident.mli
@@ -23,7 +23,7 @@ val create : ?reserved_dst:string list -> unit -> t
 
 (* Translate a string 'src' to a string 'dst', ensuring that
    'dst' is as close as possible to 'preferred_dst' and that
-   nothing else already translates to that 'dst.
+   nothing else already translates to that 'dst'.
    'preferred_dst' defaults to 'src'.
 
    This translation is remembered, with the consequence that calling this

--- a/src/gen/lib/Simplify_grammar.ml
+++ b/src/gen/lib/Simplify_grammar.ml
@@ -206,8 +206,9 @@ let alias_extras grammar =
             must_be_preserved=true;
           }
         else x)
-    (* Cases below only traverse the structure. We could cut down on boilerplate
-     * by using deriving visitors on this data structure. *)
+    (* Cases below only traverse the structure. We could cut down on
+       boilerplate by using deriving visitors on this data
+       structure. *)
     | STRING _
     | PATTERN _
     | BLANK -> x
@@ -226,26 +227,27 @@ let alias_extras grammar =
     | IMMEDIATE_TOKEN x -> IMMEDIATE_TOKEN (insert_aliases x)
     | TOKEN x -> TOKEN (insert_aliases x)
   in
-  let rules = List.map (fun (id, body) -> (id, insert_aliases body)) grammar.rules in
-  (* Later in the pipeline, ocaml-tree-sitter-core checks that each name used in
-   * an alias is associated with an actual rule. I (nmote) suspect that this
-   * isn't necessary, but for now we'll insert a blank rule for each new alias
-   * to satisfy this check.
-   * *)
+  let rules =
+    List.map (fun (id, body) -> (id, insert_aliases body)) grammar.rules in
+  (* Later in the pipeline, ocaml-tree-sitter-core checks that each
+     name used in an alias is associated with an actual rule. I
+     (nmote) suspect that this isn't necessary, but for now we'll
+     insert a blank rule for each new alias to satisfy this check.
+  *)
   let new_alias_rules = List.map (fun name -> name, BLANK) !new_aliases in
   let rules = rules @ new_alias_rules in
   let rules =
     (* Hack to work around https://github.com/tree-sitter/tree-sitter/issues/1834.
-     *
-     * Insert an unused rule that simply references each extra. This keeps
-     * tree-sitter from renaming all instances of the extra based on the alias,
-     * since it only creates a default alias if a rule appears only in aliases
-     * (see https://github.com/tree-sitter/tree-sitter/pull/1836)
+       Insert an unused rule that simply references each extra. This keeps
+       tree-sitter from renaming all instances of the extra based on the alias,
+       since it only creates a default alias if a rule appears only in aliases
+       (see https://github.com/tree-sitter/tree-sitter/pull/1836)
     *)
     let dummy_rules =
       List.mapi
         (fun i extra_name ->
-           let dummy_name = Fresh.create_name fresh ("dummy_alias" ^ (string_of_int i)) in
+           let dummy_name =
+             Fresh.create_name fresh ("dummy_alias" ^ (string_of_int i)) in
            let rule = SYMBOL extra_name in
            (dummy_name, rule)
         ) !aliased_rules

--- a/src/gen/lib/Type_name.ml
+++ b/src/gen/lib/Type_name.ml
@@ -73,6 +73,11 @@ let name_of_opt_prec_value p =
   | None -> "0"
   | Some p -> "x" ^ name_of_prec_value p
 
+let name_pattern pat =
+  match Pattern_name.infer pat with
+  | Some name -> name
+  | None -> hash_string_hex pat
+
 (*
    Similar to name_rule_body below but operates on the original tree-sitter
    grammar type (grammar.json). This is used to generate rule names
@@ -86,7 +91,7 @@ let name_ts_rule_body (body : Tree_sitter_t.rule_body) =
     | SYMBOL ident -> ident
     | STRING s -> Punct.to_alphanum s
     | BLANK -> "blank"
-    | PATTERN pat -> "pat_" ^ hash_string_hex pat
+    | PATTERN pat -> "pat_" ^ name_pattern pat
     | REPEAT x -> "rep_" ^ name_rule_body x
     | REPEAT1 x -> "rep1_" ^ name_rule_body x
     | CHOICE (x :: _) -> "choice_" ^ name_rule_body x

--- a/src/gen/lib/dune
+++ b/src/gen/lib/dune
@@ -5,6 +5,7 @@
  (libraries
    unix
    atdgen-runtime
+   re
    str
    tsort
  )
@@ -19,3 +20,5 @@
  (targets Tree_sitter_t.ml Tree_sitter_t.mli)
  (deps    Tree_sitter.atd)
  (action  (run atdgen -t %{deps})))
+
+(ocamllex Pattern_name)

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,8 @@ TESTS = \
   inline-token \
   explicit-extra \
   reserved \
-  inline
+  inline \
+  pattern-name
 
 # Build and run all the tests.
 .PHONY: test

--- a/test/pattern-name/Makefile
+++ b/test/pattern-name/Makefile
@@ -1,0 +1,1 @@
+../Makefile.common

--- a/test/pattern-name/check-test-output
+++ b/test/pattern-name/check-test-output
@@ -31,6 +31,7 @@ contains 'type pat_uppe' ocaml-src/lib/CST.ml
 contains 'type pat_mixed' ocaml-src/lib/CST.ml
 contains 'type pat_unde_sepa' ocaml-src/lib/CST.ml
 contains 'type pat_dash_sepa' ocaml-src/lib/CST.ml
+contains 'type pat_last_90_days' ocaml-src/lib/CST.ml
 
 # Collision resolution between /X/ and /x/ that both get normalized to 'x'.
 contains 'type pat_x' ocaml-src/lib/CST.ml

--- a/test/pattern-name/check-test-output
+++ b/test/pattern-name/check-test-output
@@ -1,0 +1,34 @@
+#! /usr/bin/env bash
+#
+# Check test output
+#
+set -eu
+
+contains() {
+  str=$1
+  file=$2
+  if grep -F -q "$str" "$file"; then
+    echo "OK found '$str' in '$file'"
+  else
+    echo "FAIL couldn't find '$str' in '$file'"
+  fi
+}
+
+contains 'type pat_lowe' ocaml-src/lib/CST.ml
+contains 'type pat_uppe' ocaml-src/lib/CST.ml
+contains 'type pat_mixed' ocaml-src/lib/CST.ml
+contains 'type pat_unde_sepa' ocaml-src/lib/CST.ml
+contains 'type pat_dash_sepa' ocaml-src/lib/CST.ml
+
+# Collision resolution between /X/ and /x/ that both get normalized to 'x'.
+contains 'type pat_x' ocaml-src/lib/CST.ml
+contains 'type pat_x_' ocaml-src/lib/CST.ml
+
+# Collision resolution between /-/ and /_/ that both get normalized to '_'.
+contains 'type pat__' ocaml-src/lib/CST.ml
+contains 'type pat___' ocaml-src/lib/CST.ml
+
+# Collision resolution between /#/ and /01abfc7/ that both end up being named
+# "01abfc7".
+contains 'type pat_01abfc7' ocaml-src/lib/CST.ml
+contains 'type pat_01abfc7_' ocaml-src/lib/CST.ml

--- a/test/pattern-name/check-test-output
+++ b/test/pattern-name/check-test-output
@@ -11,6 +11,18 @@ contains() {
     echo "OK found '$str' in '$file'"
   else
     echo "FAIL couldn't find '$str' in '$file'"
+    return 1
+  fi
+}
+
+doesnt_contain() {
+  str=$1
+  file=$2
+  if grep -F -q "$str" "$file"; then
+    echo "FAIL found '$str' in '$file'"
+    return 1
+  else
+    echo "OK couldn't find '$str' in '$file'"
   fi
 }
 
@@ -32,3 +44,6 @@ contains 'type pat___' ocaml-src/lib/CST.ml
 # "01abfc7".
 contains 'type pat_01abfc7' ocaml-src/lib/CST.ml
 contains 'type pat_01abfc7_' ocaml-src/lib/CST.ml
+
+# Identical patterns should get the same name
+doesnt_contain 'type pat_lowe_ ' ocaml-src/lib/CST.ml

--- a/test/pattern-name/grammar.js
+++ b/test/pattern-name/grammar.js
@@ -1,0 +1,23 @@
+/*
+  Test the inference of good names for simple patterns.
+*/
+module.exports = grammar({
+  name: 'pattern_name',
+  rules: {
+    program: $ => repeat($.element),
+    element: $ => choice(
+      /lowercase/,
+      /UPPERCASE/,
+      /[mmm][I][xX][Ee]d/,
+      /underscore_separator/,
+      /dash-separator/,
+      /42/,
+      /X/,
+      /x/, // expect different name than for /X/
+      /_/,
+      /-/, // expect different name than for /_/
+      /#/,
+      /01abfc7/, // intentional collision with the hash for /#/
+    )
+  }
+});

--- a/test/pattern-name/grammar.js
+++ b/test/pattern-name/grammar.js
@@ -12,6 +12,7 @@ module.exports = grammar({
       /underscore_separator/,
       /dash-separator/,
       /42/,
+      /[lL][aA][sS][tT][__][99][00][__][dD][aA][yY][sS]/,
       /X/,
       /x/, // expect different name than for /X/
       /_/,

--- a/test/pattern-name/grammar.js
+++ b/test/pattern-name/grammar.js
@@ -18,6 +18,10 @@ module.exports = grammar({
       /-/, // expect different name than for /_/
       /#/,
       /01abfc7/, // intentional collision with the hash for /#/
+      seq(
+        'thing',
+        /lowercase/, // duplicate, should share a name with the other copy
+      ),
     )
   }
 });

--- a/test/pattern-name/test/ok/example
+++ b/test/pattern-name/test/ok/example
@@ -1,0 +1,3 @@
+lowercase
+UPPERCASE
+mIxed

--- a/test/setup
+++ b/test/setup
@@ -23,7 +23,7 @@ for lang in $* ; do
   [DESCRIBE WHAT THIS TEST IS FOR]
 */
 module.exports = grammar({
-  name: '$lang',
+  name: '$name',
   rules: {
     program: $ => 'hello'
   }


### PR DESCRIPTION
Closes #51 

This changes type names for some patterns in the generated `CST` module. I expect this will benefit Dockerfile, Apex, and any language that uses case-insensitive keywords.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
