### PR TITLE
Fix CSV files containing aggregated errors

### DIFF
--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -92,11 +92,23 @@ def parse_json_error_log():
 
 def print_csv_clusters(clusters):
     writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
-    writer.writerow(['num errors', 'num lines', 'error class', 'code_location', 'code'])
-    for _key, clus in sorted(clusters.items(), key = lambda c: -c[1]['num_errors']):
+    writer.writerow([
+        'number of errors',
+        'number of affected lines',
+        'error class',
+        'code location',
+        'code sample',
+    ])
+    for _key, clus in sorted(clusters.items(), key = lambda c: -c[1]['num_lines']):
         code_locs_to_string = ';\n'.join(clus['code_location'])
         all_code_lines = ';\n'.join(clus['code'])
-        row = [clus['num_errors'], clus['num_lines'], clus['error_class'], code_locs_to_string, all_code_lines]
+        row = [
+            clus['num_errors'],
+            clus['num_lines'],
+            clus['error_class'],
+            code_locs_to_string,
+            all_code_lines
+        ]
         writer.writerow(row)
 
 

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -145,13 +145,7 @@ aggregate_errors() {
   header='num_errors,num_lines,error_class'
   (
     echo "$header"
-    "$progdir"/aggregate-parse-errors < "$global_json_err_log" \
-      | sort -rn -t, -k1 -k2
-  ) > "$stat"/aggregated-errors-sorted-by-count.csv
-  (
-    echo "$header"
-    "$progdir"/aggregate-parse-errors < "$global_json_err_log" \
-      | sort -rn -t, -k2 -k1
+    "$progdir"/aggregate-parse-errors < "$global_json_err_log"
   ) > "$stat"/aggregated-errors-sorted-by-line-count.csv
 }
 

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -143,10 +143,8 @@ EOF
 
 aggregate_errors() {
   header='num_errors,num_lines,error_class'
-  (
-    echo "$header"
-    "$progdir"/aggregate-parse-errors < "$global_json_err_log"
-  ) > "$stat"/aggregated-errors-sorted-by-line-count.csv
+  "progdir"/aggregate-parse-errors < "$global_json_err_log" \
+    > "$stat"/aggregated-errors.csv
 }
 
 main() {

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -143,7 +143,7 @@ EOF
 
 aggregate_errors() {
   header='num_errors,num_lines,error_class'
-  "progdir"/aggregate-parse-errors < "$global_json_err_log" \
+  "$progdir"/aggregate-parse-errors < "$global_json_err_log" \
     > "$stat"/aggregated-errors.csv
 }
 


### PR DESCRIPTION
The problem was that CSV rows can span multiple lines if some cell contains a newline, so we can't sort the lines of a CSV file and expect correct results.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
