### PR TITLE
Fix make stat and aggregate-parse-errors

### DIFF
--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -91,7 +91,7 @@ def parse_json_error_log():
     return clusters
 
 def print_csv_clusters(clusters):
-    writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
+    writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL, escapechar='\\')
     writer.writerow([
         'number of errors',
         'number of affected lines',


### PR DESCRIPTION
This is the same than https://github.com/returntocorp/ocaml-tree-sitter-core/pull/24

test plan:
make stat in the rust and python directories now work on my
Arch linux machine (Python 3.10.5)


### Security

- [x] Change has no security implications (otherwise, ping the security team)