### PR TITLE
Add jsoo support

### DIFF
--- a/src/run/lib/Src_file.ml
+++ b/src/run/lib/Src_file.ml
@@ -48,31 +48,8 @@ let load_string ?(src_name = "<source>") ?src_file src_contents =
     lines = Array.of_list lines;
   }
 
-(*
-   Non-trivial function to read correctly from any kind of file,
-   including named pipes such as those created by bash via
-   "process substitution" e.g. echo <(echo hello)
-*)
-let read_file path =
-  let buf_len = 4096 in
-  let extbuf = Buffer.create 4096 in
-  let buf = Bytes.create buf_len in
-  let rec loop fd =
-    match Unix.read fd buf 0 buf_len with
-    | 0 -> Buffer.contents extbuf
-    | num_bytes ->
-        assert (num_bytes > 0);
-        assert (num_bytes <= buf_len);
-        Buffer.add_subbytes extbuf buf 0 num_bytes;
-        loop fd
-  in
-  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
-  Fun.protect
-    ~finally:(fun () -> Unix.close fd)
-    (fun () -> loop fd)
-
 let load_file path =
-  let data = read_file path in
+  let data = Util_file.read_file path in
   load_string ~src_name:path ~src_file:path data
 
 let safe_get_row x row =

--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -6,7 +6,7 @@
  * so some functions can change their implementation and rely
  * less on non-portable API like Unix which does not work well under
  * node or in the browser.
- *)
+*)
 let jsoo = ref false
 
 (*
@@ -32,22 +32,22 @@ let jsoo = ref false
 
 let read_file path =
   if !jsoo then (let ic = open_in_bin path in
-  let s = really_input_string ic (in_channel_length ic) in
-  close_in ic;
-  s) else
-  let buf_len = 4096 in
-  let extbuf = Buffer.create 4096 in
-  let buf = Bytes.create buf_len in
-  let rec loop fd =
-    match Unix.read fd buf 0 buf_len with
-    | 0 -> Buffer.contents extbuf
-    | num_bytes ->
-        assert (num_bytes > 0);
-        assert (num_bytes <= buf_len);
-        Buffer.add_subbytes extbuf buf 0 num_bytes;
-        loop fd
-  in
-  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
-  Fun.protect
-    ~finally:(fun () -> Unix.close fd)
-    (fun () -> loop fd)
+                 let s = really_input_string ic (in_channel_length ic) in
+                 close_in ic;
+                 s) else
+    let buf_len = 4096 in
+    let extbuf = Buffer.create 4096 in
+    let buf = Bytes.create buf_len in
+    let rec loop fd =
+      match Unix.read fd buf 0 buf_len with
+      | 0 -> Buffer.contents extbuf
+      | num_bytes ->
+          assert (num_bytes > 0);
+          assert (num_bytes <= buf_len);
+          Buffer.add_subbytes extbuf buf 0 num_bytes;
+          loop fd
+    in
+    let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+    Fun.protect
+      ~finally:(fun () -> Unix.close fd)
+      (fun () -> loop fd)

--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -2,6 +2,13 @@
    Generic utilities not provided by OCaml.
 *)
 
+(* You should set this to true when you run code compiled by js_of_ocaml
+ * so some functions can change their implementation and rely
+ * less on non-portable API like Unix which does not work well under
+ * node or in the browser.
+ *)
+let jsoo = ref false
+
 (*
    [copied from pfff/commons/Common.ml]
 
@@ -22,7 +29,12 @@
    Why such a function is not provided by the ocaml standard library is
    unclear.
 *)
+
 let read_file path =
+  if !jsoo then (let ic = open_in_bin path in
+  let s = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  s) else
   let buf_len = 4096 in
   let extbuf = Buffer.create 4096 in
   let buf = Bytes.create buf_len in

--- a/src/run/lib/Util_file.mli
+++ b/src/run/lib/Util_file.mli
@@ -2,6 +2,9 @@
    Generic file utilities not provided by OCaml.
 *)
 
+(* you should set this flag when you run code compiled by js_of_ocaml *)
+val jsoo : bool ref
+
 (* Read the contents of file.
 
    This implementation works even with Linux files like /dev/fd/63


### PR DESCRIPTION
This PR allows us to disable the special unix-y file reading machinery of `read_file` via the `Util_file.jsoo` ref. This is necessary in order for semgrep to run in the browser.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
