### PR TITLE
pass -I TREESITTER_INCDIR to cxx files as well

### DIFF
--- a/scripts/ocaml-tree-sitter-gen-ocaml
+++ b/scripts/ocaml-tree-sitter-gen-ocaml
@@ -253,6 +253,7 @@ cat > "$dst_dir"/lib/dune <<EOF
     (language cxx)
     (names ${cxx_files})
     (flags -fPIC
+           -I %{env:TREESITTER_INCDIR=/usr/local/include}
            -I .)
   )
 )


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
