### PR TITLE
refactor: no longer emit dune files that use `ppx_sexp_conv`

### DIFF
--- a/scripts/ocaml-tree-sitter-gen-ocaml
+++ b/scripts/ocaml-tree-sitter-gen-ocaml
@@ -216,7 +216,6 @@ cat > "$dst_dir"/lib/dune <<EOF
 (library
   (public_name $package.${lang_dashes})
   (name tree_sitter_${lang_underscores})
-  (preprocess (pps ppx_sexp_conv))
   (libraries atdgen-runtime tree-sitter.run)
 
   ; A copy of the C headers for the tree-sitter library is found locally.

--- a/src/run/lib/dune
+++ b/src/run/lib/dune
@@ -1,7 +1,6 @@
 (library
  (public_name tree-sitter.run)
  (name tree_sitter_run)
- (preprocess (pps ppx_sexp_conv))
  (libraries
    ANSITerminal
    atdgen-runtime

--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -22,7 +22,6 @@ depends: [
   "dune" {>= "2.1"}
   "ocaml"
   "ppx_deriving"
-  "ppx_sexp_conv"
   "sexplib"
   "tsort" {>= "2.0"}
 ]


### PR DESCRIPTION
## What:
This PR makes it so the `dune` files we produce no longer depend on `ppx_sexp_conv`.

## Why:
We are trying to upgrade to OCaml 5.0, which has a conflict with the `ppx_sexp_conv` version we are currently using. Unfortunately, newer versions of that package make our code also not compile, due to an issue https://github.com/janestreet/ppx_sexp_conv/issues/40.

It's easier to just rip out `ppx_sexp_conv` (which we are already no longer making use of) entirely. To that end, we have to make sure we stop generating code which relies on it.

## Test plan:
Not sure what the best way to proceed here is. `make test` succeeds, at any rate. This should only present an issue if we use `ppx_sexp_conv`, which we shouldn't once we update all the relevant repositories in Semgrep.

Unfortunately, I think that even if we merge this, we are going to have to upgrade every single `semgrep-*` repository, because all of them have dune files which currently depend on `ppx_sexp_conv`, and we aren't going to be able to compile while those files stay the way that they are.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
