### PR TITLE
More fixes and improvements in error highlighting

### DIFF
--- a/src/run/lib/Main.ml
+++ b/src/run/lib/Main.ml
@@ -126,9 +126,6 @@ let parse_command_line ~lang =
   | `Version | `Help -> exit 0
   | `Ok config -> config
 
-let use_color () =
-  !ANSITerminal.isatty Unix.stderr
-
 let safe_run f =
   Printexc.record_backtrace true;
   try f ()
@@ -138,7 +135,7 @@ let safe_run f =
     let msg, exit_code, show_trace =
       match e with
       | Tree_sitter_error.Error err ->
-          let msg = Tree_sitter_error.to_string ~color:(use_color ()) err in
+          let msg = Tree_sitter_error.to_string ~style:Auto err in
           let exit_code =
             match err.kind with
             | External -> Exit.external_parsing_error
@@ -164,7 +161,7 @@ let safe_run f =
 
 let print_error err =
   eprintf "Error: %s\n"
-    (Tree_sitter_error.to_string ~color:(use_color ()) err)
+    (Tree_sitter_error.to_string ~style:Auto err)
 
 let print_errors errors =
   List.iter print_error errors

--- a/src/run/lib/Snippet.ml
+++ b/src/run/lib/Snippet.ml
@@ -173,7 +173,15 @@ let format_underline buf ~color line =
     ) line
   )
 
-let format ~color lines =
+type style = Auto | Color | Text
+
+let format ~style lines =
+  let color =
+    match style with
+    | Auto -> Unix.(isatty stdout) && Unix.(isatty stderr)
+    | Color -> true
+    | Text -> false
+  in
   let buf = Buffer.create 1000 in
   lines
   |> List.iter (fun line ->

--- a/src/run/lib/Snippet.ml
+++ b/src/run/lib/Snippet.ml
@@ -16,6 +16,7 @@ type snippet_line = snippet_fragment list
 
 type t = snippet_line list
 
+(* Split string at the specified position. *)
 let split s pos2 =
   let a = Util_string.safe_sub s 0 pos2 in
   let b = Util_string.safe_sub s pos2 (String.length s - pos2) in
@@ -56,29 +57,12 @@ let shorten_snippet_line line =
 let shorten_snippet_lines lines =
   List.map shorten_snippet_line lines
 
-let rec list_last = function
-  | [x] -> Some x
-  | _ :: xs -> list_last xs
-  | [] -> None
-
-let add_missing_newline_to_line line =
-  match list_last line with
-  | None -> line
-  | Some last_fragment ->
-      let misses_newline =
-        match last_fragment with
-        | Ellipsis -> true
-        | (Normal s
-          | Highlight s) ->
-            s = "" || s.[String.length s - 1] <> '\n'
-      in
-      if misses_newline then
-        line @ [Normal "\n"]
-      else
-        line
-
-let add_missing_newlines lines =
-  List.map add_missing_newline_to_line lines
+(* Ensure all lines are LF-terminated. *)
+let add_missing_newline line =
+  if line = "" || line.[String.length line - 1] <> '\n' then
+    line ^ "\n"
+  else
+    line
 
 let extract
     ?(lines_before = 2)
@@ -104,7 +88,10 @@ let extract
     let line_acc = ref [] in
     let add line = line_acc := line :: !line_acc in
     for line_num = snip_start_line to snip_end_line - 1 do
-      let line = Src_file.safe_get_row src line_num in
+      let line =
+        Src_file.safe_get_row src line_num
+        |> add_missing_newline
+      in
       if line_num < start_line || line_num >= end_line then
         (* Highlight nothing. *)
         add [Normal line]
@@ -189,7 +176,6 @@ let format_underline buf ~color line =
 let format ~color lines =
   let buf = Buffer.create 1000 in
   lines
-  |> add_missing_newlines
   |> List.iter (fun line ->
     format_line buf ~color line;
     format_underline buf ~color line;

--- a/src/run/lib/Snippet.mli
+++ b/src/run/lib/Snippet.mli
@@ -30,7 +30,7 @@ val extract :
   end_pos:position -> Src_file.t -> t
 
 type style =
-  | Auto (* best-effort guess *)
+  | Auto (* best-effort guess based on stdout and stderr *)
   | Color (* use ANSI-terminal-compatible highlighting *)
   | Text (* use text-based highlighting *)
 

--- a/src/run/lib/Snippet.mli
+++ b/src/run/lib/Snippet.mli
@@ -32,7 +32,8 @@ val extract :
 (*
    Render a snippet as text. If 'color' is true, the output will use
    color in a manner compatible with an ANSI terminal. Otherwise
-   the text to be highlighted is underlined with '^^^'.
+   the text to be highlighted is underlined with '^^^'. The latter will
+   produce incorrect results on lines containing multi-byte characters.
 
    Missing newlines are added automatically.
 *)

--- a/src/run/lib/Snippet.mli
+++ b/src/run/lib/Snippet.mli
@@ -29,6 +29,11 @@ val extract :
   start_pos:position ->
   end_pos:position -> Src_file.t -> t
 
+type style =
+  | Auto (* best-effort guess *)
+  | Color (* use ANSI-terminal-compatible highlighting *)
+  | Text (* use text-based highlighting *)
+
 (*
    Render a snippet as text. If 'color' is true, the output will use
    color in a manner compatible with an ANSI terminal. Otherwise
@@ -37,4 +42,4 @@ val extract :
 
    Missing newlines are added automatically.
 *)
-val format : color:bool -> t -> string
+val format : style:style -> t -> string

--- a/src/run/lib/Tree_sitter_error.ml
+++ b/src/run/lib/Tree_sitter_error.ml
@@ -125,7 +125,7 @@ let string_of_file_info (src_info : Src_file.info) =
    in a human-readable and possibly computer-readable format (TODO check with
    emacs etc.)
 *)
-let to_string ?(color = false) (err : t) =
+let to_string ?(style = Snippet.Text) (err : t) =
   let start = err.start_pos in
   let end_ = err.end_pos in
   let loc =
@@ -149,7 +149,7 @@ let to_string ?(color = false) (err : t) =
 %s
 %s%s%s"
     loc
-    (Snippet.format ~color err.snippet)
+    (Snippet.format ~style err.snippet)
     error_class
     err.msg
 

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -102,7 +102,7 @@ val internal_error :
    Format an error message. Highlight the error for an ANSI terminal iff
    'color' is true. 'color' is false by default.
 *)
-val to_string : ?color:bool -> t -> string
+val to_string : ?style:Snippet.style -> t -> string
 
 (*
    Append errors to error log in json format, one object per line.

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -99,8 +99,8 @@ val internal_error :
   string -> 'a
 
 (*
-   Format an error message. Highlight the error for an ANSI terminal iff
-   'color' is true. 'color' is false by default.
+   Format an error message. Highlight the error according to the value
+   of 'style' whose default is 'Auto' (see the Snippet module for details).
 *)
 val to_string : ?style:Snippet.style -> t -> string
 

--- a/src/run/test/Snippet.ml
+++ b/src/run/test/Snippet.ml
@@ -8,7 +8,7 @@ open Printf
 open Tree_sitter_run
 
 let check_format_with_color (lines, expected_res) =
-  let res = Snippet.format ~color:true lines in
+  let res = Snippet.format ~style:Color lines in
   printf "Highlighted result:\n%s" res;
   (* This is for copy-pasting the expected string into the OCaml test: *)
   printf "Same, OCaml-escaped: %S\n" res;
@@ -16,7 +16,7 @@ let check_format_with_color (lines, expected_res) =
   Alcotest.(check string) "equal" expected_res res
 
 let check_format_without_color (lines, expected_res) =
-  let res = Snippet.format ~color:false lines in
+  let res = Snippet.format ~style:Text lines in
   printf "Highlighted result:\n%s" res;
   (* This is for copy-pasting the expected string into the OCaml test: *)
   printf "Same, OCaml-escaped: %S\n" res;
@@ -82,7 +82,7 @@ let highlight
   let start_pos : Loc.pos = { row = start_row; column = start_column } in
   let end_pos : Loc.pos = { row = end_row; column = end_column } in
   Snippet.extract ~start_pos ~end_pos src
-  |> Snippet.format ~color:false
+  |> Snippet.format ~style:Text
 
 let check_extract
     ~data ?start_row ?start_column ?end_row ?end_column

--- a/src/run/test/Snippet.ml
+++ b/src/run/test/Snippet.ml
@@ -27,12 +27,12 @@ let test_format_with_color () =
   (* The expected output is meant to be copy pasted from the test output. *)
   let data : (Snippet.t * string) list = [
     [
-      [Normal "A"; Highlight "H"; Normal "B" ]
+      [Normal "A"; Highlight "H"; Normal "B\n" ]
     ], "A\027[1;4;31mH\027[0mB\n";
     [
-      [Normal "A"];
-      [Normal "B"; Highlight "H"; Normal "C" ];
-      [Normal "D"];
+      [Normal "A\n"];
+      [Normal "B"; Highlight "H"; Normal "C\n" ];
+      [Normal "D\n"];
     ], "A\nB\027[1;4;31mH\027[0mC\nD\n";
     [
       [Normal "A\n"];
@@ -44,7 +44,7 @@ let test_format_with_color () =
        function by creating nonempty Highlight fragments for one character. *)
     [
       [Normal "highlight newline:"; Highlight "\n"];
-      [Normal "N"]
+      [Normal "N\n"]
     ], "highlight newline:\027[1;4;31m \n\027[0mN\n";
   ] in
   data
@@ -54,12 +54,12 @@ let test_format_without_color () =
   (* The expected output is meant to be copy pasted from the test output. *)
   let data : (Snippet.t * string) list = [
     [
-      [Normal "A"; Highlight "H"; Normal "B" ]
+      [Normal "A"; Highlight "H"; Normal "B\n" ]
     ], "AHB\n ^ \n";
     [
-      [Normal "A"];
-      [Normal "B"; Highlight "H"; Normal "C" ];
-      [Normal "D"];
+      [Normal "A\n"];
+      [Normal "B"; Highlight "H"; Normal "C\n" ];
+      [Normal "D\n"];
     ], "A\nBHC\n ^ \nD\n";
     [
       [Normal "A\n"];
@@ -68,13 +68,64 @@ let test_format_without_color () =
     ], "A\nH\n^\nB\n";
     [
       [Normal "highlight newline:"; Highlight "\n"];
-      [Normal "N"]
+      [Normal "N\n"]
     ], "highlight newline: \n                  ^\nN\n";
   ] in
   data
   |> List.iter check_format_without_color
 
+let highlight
+    ~data ?(start_row = 0) ?(start_column = 0) ?end_row ?end_column () =
+  let src = Src_file.load_string ~src_name:"test input" data in
+  let end_row = Option.value end_row ~default:start_row in
+  let end_column = Option.value end_column ~default:start_column in
+  let start_pos : Loc.pos = { row = start_row; column = start_column } in
+  let end_pos : Loc.pos = { row = end_row; column = end_column } in
+  Snippet.extract ~start_pos ~end_pos src
+  |> Snippet.format ~color:false
+
+let check_extract
+    ~data ?start_row ?start_column ?end_row ?end_column
+    expected_res =
+  let res = highlight ~data ?start_row ?start_column ?end_row ?end_column () in
+  printf "Highlighted result:\n%s" res;
+  printf "Same, OCaml-escaped: %S\n" res;
+  printf "           Expected: %S\n" expected_res;
+  Alcotest.(check string) "equal" expected_res res
+
+let test_extract () =
+  check_extract
+    ~data:"<- this"
+    "<- this\n^      \n";
+  check_extract
+    ~data:"->this<-"
+    ~start_column:2
+    ~end_column:6
+    "->this<-\n  ^^^^  \n";
+  check_extract
+    ~data:"this empty region: -><-"
+    ~start_column:21
+    ~end_column:21
+    "this empty region: -><-\n                     ^ \n";
+  check_extract
+    ~data:"empty location at the end of next line:\n->\n"
+    ~start_row:1
+    ~start_column:2
+    ~end_column:2
+    "empty location at the end of next line:\n-> \n  ^\n\n";
+  check_extract
+    ~data:"empty location at the end of next line, no newline:\n->"
+    ~start_row:1
+    ~start_column:2
+    ~end_column:2
+    "empty location at the end of next line, no newline:\n-> \n  ^\n";
+  check_extract
+    ~data:"\240\159\152\129 <- this 4-byte emoji is incorrectly highlighted"
+    ~end_column:4
+    "\240\159\152\129 <- this 4-byte emoji is incorrectly highlighted\n^^^^                                                \n"
+
 let test = "Snippet", [
   "highlight snippet with color", `Quick, test_format_with_color;
   "highlight snippet without color", `Quick, test_format_without_color;
+  "extract and highlight snippet", `Quick, test_extract;
 ]


### PR DESCRIPTION
* fixes highlighting of zero-width region at the end of a snippet that's not LF-terminated (screenshot below)
* adds `style:Auto` option for guessing the best way to highlight a snippet (color or not).

![image](https://github.com/returntocorp/ocaml-tree-sitter-core/assets/343265/9730b8a8-ab32-400b-a23e-3526b250216c)

test plan: unit tests were added -> `make test`

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
