### PR TITLE
Distinguish missing nodes from error nodes

### DIFF
--- a/src/run/lib/Main.ml
+++ b/src/run/lib/Main.ml
@@ -138,7 +138,7 @@ let safe_run f =
           let msg = Tree_sitter_error.to_string ~style:Auto err in
           let exit_code =
             match err.kind with
-            | External -> Exit.external_parsing_error
+            | Error_node | Missing_node -> Exit.external_parsing_error
             | Internal -> Exit.internal_parsing_error
           in
           msg, exit_code, false

--- a/src/run/lib/Run.ml
+++ b/src/run/lib/Run.ml
@@ -204,11 +204,11 @@ let extract_errors src root_node =
     match error_kind with
     | Error_node ->
         Tree_sitter_error.create
-          Tree_sitter_error_t.External src ?parent node
+          Tree_sitter_error_t.Error_node src ?parent node
           "Unrecognized construct"
     | Missing_node ->
         Tree_sitter_error.create
-          Tree_sitter_error_t.External src ?parent node
+          Tree_sitter_error_t.Missing_node src ?parent node
           ("Missing element in input code: " ^
            (match node.kind with
             | Literal s -> Printf.sprintf "%S" s

--- a/src/run/lib/Tree_sitter_error.atd
+++ b/src/run/lib/Tree_sitter_error.atd
@@ -9,8 +9,11 @@ type position <ocaml from="Tree_sitter_bindings.Tree_sitter_output"
                      t="position"> = abstract
 
 type error_kind = [
-  | Internal (* a bug *)
-  | External (* malformed input or bug, but we don't know *)
+  | Internal (* bug in the translation from one tree type to another *)
+  | Error_node (* a subtree that can be ignored while preserving the
+                  well-formedness of the CST *)
+  | Missing_node (* a fake node inserted by the parser to fix an ill-formed
+                    CST. *)
 ] <ocaml repr="classic">
 
 (*
@@ -23,6 +26,6 @@ type json_error = {
   file: string;
   start_pos: position;
   end_pos: position;
-  substring: string;
+  substring: string; (* empty for a Missing_node *)
   ?error_class: string option;
 }

--- a/src/run/lib/Tree_sitter_error.ml
+++ b/src/run/lib/Tree_sitter_error.ml
@@ -110,9 +110,6 @@ let create kind src ?parent node msg =
 let fail kind src node msg =
   raise (Error (create kind src node msg))
 
-let external_error src node msg =
-  fail External src node msg
-
 let internal_error src node msg =
   fail Internal src node msg
 

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -79,16 +79,6 @@ val create :
   string -> t
 
 (*
-   Fail, raising an External_error exception.
-   The string argument is an arbitrary message to be printed as part of
-   an error message.
-*)
-val external_error :
-  Src_file.t ->
-  Tree_sitter_bindings.Tree_sitter_output_t.node ->
-  string -> 'a
-
-(*
    Fail, raising an Internal_error exception.
    The string argument is an arbitrary message to be printed as part of
    an error message.


### PR DESCRIPTION
* Previously, the kind of error was guessed based on the value of the token (empty => missing node)
* This doesn't break Semgrep and doesn't need regenerating OCaml code.

This is used by https://github.com/returntocorp/semgrep/pull/8190

test plan: `make && make test`

### Security

- [x] Change has no security implications (otherwise, ping the security team)
