### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,0 @@
-# Together with the correct GitHub project setting, this limits who can
-# approve pull requests.
-# It's also used by GitHub to suggest reviewers.
-
-# Default owners:
-# Program Analysis team at r2c
-* @returntocorp/pa


### PR DESCRIPTION
 This is in an attempt to not send PR notifications to everyone on the PA team. The original intent was to prevent non-PA to bypass PA review. Maybe there's another way to achieve this.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
