### PR TITLE
add dune-configurator to dependencies

### DIFF
--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -20,6 +20,7 @@ depends: [
   "cmdliner"
   "conf-pkg-config"
   "dune" {>= "2.1"}
+  "dune-configurator" {>= "3.10.0"}
   "ocaml"
   "ppx_deriving"
   "sexplib"


### PR DESCRIPTION
Add 'dune-configurator' to the depedencies in
tree-sitter.opam to avoid a build error when
running `./scripts/rebuild-everything`.

Fix #71.

### Security

- [X ] Change has no security implications (otherwise, ping the security team)
