### PR TITLE
fix: raise on NULL return from ts_parser_parse to prevent segfault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ test: build
 # Run unit tests only (takes a few seconds).
 .PHONY: unit
 unit: build
-	./_build/default/src/test/test.exe
+	LD_LIBRARY_PATH=$(TREESITTER_LIBDIR):$(LD_LIBRARY_PATH) \
+	  ./_build/default/src/test/test.exe
 
 # Run end-to-end tests (takes a few minutes).
 .PHONY: e2e

--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -24,6 +24,7 @@
 #include <tree_sitter/api.h>
 
 #include <caml/alloc.h>
+#include <caml/fail.h>
 #include <caml/bigarray.h>
 #include <caml/callback.h>
 #include <caml/custom.h>
@@ -109,6 +110,9 @@ CAMLprim value octs_parser_parse(value vParser, value vTree, value vRead) {
 
   TSTree *tree = ts_parser_parse(tsparser, oldTree, input);
 
+  if (tree == NULL)
+    caml_failwith("ts_parser_parse returned NULL (no language set, or parse was cancelled)");
+
   tree_W treeWrapper;
   treeWrapper.tree = tree;
   ret = caml_alloc_custom(&tree_custom_ops, sizeof(tree_W), 0, 1);
@@ -127,6 +131,9 @@ CAMLprim value octs_parser_parse_string(value vParser, value vSource) {
   const char *source_code = String_val(vSource);
   TSTree *tree =
       ts_parser_parse_string(tsparser, NULL, source_code, caml_string_length(vSource));
+
+  if (tree == NULL)
+    caml_failwith("ts_parser_parse_string returned NULL (no language set, or parse was cancelled)");
 
   tree_W treeWrapper;
   treeWrapper.tree = tree;

--- a/src/bindings/test/Null_tree.ml
+++ b/src/bindings/test/Null_tree.ml
@@ -1,0 +1,34 @@
+(*
+   Regression test for NULL tree dereference.
+
+   ts_parser_parse_string returns NULL when:
+   1. No language is set on the parser (e.g. ABI version mismatch
+      causes ts_parser_set_language to return false, unchecked by
+      the generated code).
+   2. Parsing was cancelled via timeout or cancellation flag.
+
+   The binding in octs_parser_parse_string must detect NULL and
+   raise an exception rather than wrapping it in a custom block
+   that will segfault on the next tree operation.
+*)
+
+open Tree_sitter_bindings.Tree_sitter_API
+
+(* C stubs -- see null_tree_stubs.c *)
+external create_parser_no_language :
+  unit -> ts_parser = "octs_test_create_parser_no_language"
+
+(* parse_string on a languageless parser must raise, not return
+   a wrapper around NULL. *)
+let test_parse_string_raises_on_null () =
+  let parser = create_parser_no_language () in
+  match Parser.parse_string parser "int x = 1;" with
+  | exception Failure _ -> ()
+  | _ ->
+      Alcotest.fail
+        "parse_string should raise Failure when tree-sitter returns NULL"
+
+let test = "Null tree", [
+  "parse_string raises on NULL return",
+  `Quick, test_parse_string_raises_on_null;
+]

--- a/src/bindings/test/dune
+++ b/src/bindings/test/dune
@@ -1,0 +1,12 @@
+(library
+  (name test_tree_sitter_bindings)
+  (libraries tree_sitter_bindings alcotest)
+  (foreign_stubs
+    (language c)
+    (names null_tree_stubs)
+    (flags
+      :standard
+      -I %{env:TREESITTER_INCDIR=/usr/local/include}
+    )
+  )
+)

--- a/src/bindings/test/null_tree_stubs.c
+++ b/src/bindings/test/null_tree_stubs.c
@@ -1,0 +1,48 @@
+/*
+   C stubs for the Null_tree test module.
+
+   Exposes operations not reachable from the normal OCaml API,
+   allowing the test to exercise the NULL-return code path in
+   octs_parser_parse_string.
+*/
+
+#include <string.h>
+#include "test_helpers.h"
+
+/*
+   Create a TSParser with no language set, wrapped as an OCaml custom
+   block identical to what the generated octs_create_parser_<lang>
+   produces.
+
+   This simulates the state reached when ts_parser_set_language()
+   returns false (ABI version mismatch) and the return value is
+   not checked -- which is exactly what the generated code does.
+*/
+
+static void finalize_test_parser(value v) {
+  parser_W *p = (parser_W *)Data_custom_val(v);
+  if (p->parser)
+    ts_parser_delete(p->parser);
+}
+
+static struct custom_operations test_parser_ops = {
+  .identifier = "test parser",
+  .finalize = finalize_test_parser,
+  .compare = custom_compare_default,
+  .hash = custom_hash_default,
+  .serialize = custom_serialize_default,
+  .deserialize = custom_deserialize_default,
+};
+
+CAMLprim value octs_test_create_parser_no_language(value unit) {
+  CAMLparam1(unit);
+  CAMLlocal1(v);
+
+  parser_W pw;
+  pw.parser = ts_parser_new();
+  /* Intentionally do NOT call ts_parser_set_language(). */
+
+  v = caml_alloc_custom(&test_parser_ops, sizeof(parser_W), 0, 1);
+  memcpy(Data_custom_val(v), &pw, sizeof(parser_W));
+  CAMLreturn(v);
+}

--- a/src/bindings/test/test.ml
+++ b/src/bindings/test/test.ml
@@ -1,0 +1,7 @@
+(*
+   All the unit tests for the tree-sitter bindings library.
+*)
+
+let test_suites : unit Alcotest.test list = [
+  Null_tree.test;
+]

--- a/src/bindings/test/test_helpers.h
+++ b/src/bindings/test/test_helpers.h
@@ -1,0 +1,25 @@
+/*
+   Shared definitions for C test stubs.
+
+   These struct layouts must match src/bindings/lib/bindings.c.
+*/
+
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+#include <tree_sitter/api.h>
+
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+typedef struct _parser {
+  TSParser *parser;
+} parser_W;
+
+typedef struct _tree {
+  TSTree *tree;
+} tree_W;
+
+#endif

--- a/src/test/dune
+++ b/src/test/dune
@@ -3,5 +3,6 @@
   (libraries
     test_tree_sitter_gen
     test_tree_sitter_run
+    test_tree_sitter_bindings
   )
 )

--- a/src/test/test.ml
+++ b/src/test/test.ml
@@ -5,6 +5,7 @@
 let test_suites = List.flatten [
   Test_tree_sitter_gen.Test.test_suites;
   Test_tree_sitter_run.Test.test_suites;
+  Test_tree_sitter_bindings.Test.test_suites;
 ]
 
 let main () = Alcotest.run "ocaml-tree-sitter" test_suites


### PR DESCRIPTION
`ts_parser_parse` and `ts_parser_parse_string` can return NULL (no language set, timeout, or cancellation), per the comment in api.h. The binding wrapped the result unconditionally, producing a custom block with a NULL pointer that segfaults on the next tree operation.  This patch adds a NULL check and raises Failure instead in such cases.

Additionally, this patch introduces a a regression test, written by Claude, that exercises the NULL path via a languageless parser.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
