### PR TITLE
fix(API): make global read callback a DLS value

### DIFF
--- a/src/bindings/lib/Tree_sitter_API.ml
+++ b/src/bindings/lib/Tree_sitter_API.ml
@@ -29,13 +29,14 @@ module Parser = struct
     ts_parser -> ts_tree option -> read_function -> ts_tree
     = "octs_parser_parse"
 
-  let parse_read_function = (ref (fun _ _ _ -> None) : read_function ref)
+  let parse_read_function : read_function Domain.DLS.key =
+    Domain.DLS.new_key (fun () -> fun _ _ _ -> None)
 
   let parse_read (byte_offset : int) (row : int) (col : int) =
-    !parse_read_function byte_offset row col
+    (Domain.DLS.get parse_read_function) byte_offset row col
 
   let parse (parser : t) (tree : ts_tree option) read_function =
-    parse_read_function := read_function;
+    Domain.DLS.set parse_read_function read_function;
     parse parser tree parse_read
 
   let () = Callback.register "octs__parse_read" parse_read


### PR DESCRIPTION
The Tree-sitter API's `Parser` module contains a `read_function ref`, which is mutated on calls to `parse`.  In addition to being non-reentrant, this is also not threadsafe.  This patch addresses the latter by storing the callback in domain-local state.

More broadly, we should be using `vRead` in the supplied payload, but that's a more invasive change.  Since to the best of my knowledge no parser of ours is reentrant, this should be good enough for the moment.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
