### PR TITLE
chore: migrate CLI binaries to cmdliner 2.x API

### DIFF
--- a/src/gen/bin/Ocaml_tree_sitter_main.ml
+++ b/src/gen/bin/Ocaml_tree_sitter_main.ml
@@ -140,7 +140,7 @@ let simplify_cmd =
     `P "Check out bug reports at
         https://github.com/semgrep/ocaml-tree-sitter-core/issues.";
   ] in
-  let info = Term.info ~doc ~man "simplify" in
+  let info = Cmd.info ~doc ~man "simplify" in
   let config grammar output_path =
     Simplify { grammar; output_path }
   in
@@ -148,7 +148,7 @@ let simplify_cmd =
     const config
     $ grammar_term
     $ output_file_term) in
-  (cmdline_term, info)
+  Cmd.v info cmdline_term
 
 let to_js_cmd =
   let input_path_term =
@@ -209,7 +209,7 @@ let to_js_cmd =
     `P "Check out bug reports at
         https://github.com/semgrep/ocaml-tree-sitter-core/issues.";
   ] in
-  let info = Term.info ~doc ~man "to-js" in
+  let info = Cmd.info ~doc ~man "to-js" in
   let config input_path output_path sort_choices sort_rules strip normalize =
     let sort_choices, sort_rules, strip =
       normalize || sort_choices,
@@ -226,7 +226,7 @@ let to_js_cmd =
     $ sort_rules_term
     $ strip_term
     $ normalize_term) in
-  (cmdline_term, info)
+  Cmd.v info cmdline_term
 
 let gen_cmd =
   let config lang grammar out_dir =
@@ -255,12 +255,11 @@ let gen_cmd =
       https://github.com/semgrep/ocaml-tree-sitter-core/issues.";
   ] in
   let version = "0.0.0" in
-  let info = Term.info ~version ~doc ~man "gen" in
+  let info = Cmd.info ~version ~doc ~man "gen" in
 
-  (cmdline_term, info)
+  Cmd.v info cmdline_term
 
-let root_cmd =
-  let root_term = Term.(ret (const ((`Help (`Pager, None))))) in
+let root_info =
   let man = [
     `S Manpage.s_description;
     `P "Generate OCaml parsers based on tree-sitter grammars";
@@ -271,16 +270,16 @@ let root_cmd =
       https://github.com/semgrep/ocaml-tree-sitter-core/issues.";
   ] in
   let doc = "Generate OCaml parsers based on tree-sitter grammars" in
-  let info = Term.info ~man ~doc "ocaml-tree-sitter" in
-  (root_term, info)
+  Cmd.info ~man ~doc "ocaml-tree-sitter"
 
 let subcommands = [gen_cmd; simplify_cmd; to_js_cmd]
 
 let parse_command_line () : cmd_conf =
-  match Term.eval_choice root_cmd subcommands with
-  | `Error _ -> exit 1
-  | `Version | `Help -> exit 0
-  | `Ok conf -> conf
+  let default = Term.(ret (const (`Help (`Pager, None)))) in
+  match Cmd.eval_value (Cmd.group ~default root_info subcommands) with
+  | Ok (`Ok conf) -> conf
+  | Ok (`Version | `Help) -> exit 0
+  | Error _ -> exit 1
 
 let main () =
   Printexc.record_backtrace true;

--- a/src/run/lib/Main.ml
+++ b/src/run/lib/Main.ml
@@ -116,15 +116,15 @@ of the full CST by ocaml-tree-sitter."
 
 let parse_command_line ~lang =
   let info =
-    Term.info
+    Cmd.info
       ~doc:(doc ~lang)
       ~man:(man ~lang)
       ("parse-" ^ lang)
   in
-  match Term.eval (cmdline_term, info) with
-  | `Error _ -> exit Exit.bad_command_line
-  | `Version | `Help -> exit 0
-  | `Ok config -> config
+  match Cmd.eval_value (Cmd.v info cmdline_term) with
+  | Ok (`Ok config) -> config
+  | Ok (`Version | `Help) -> exit 0
+  | Error _ -> exit Exit.bad_command_line
 
 let safe_run f =
   Printexc.record_backtrace true;

--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest"
   "ANSITerminal"
   "atdgen"
-  "cmdliner" { < "2.0.0" }
+  "cmdliner" { >= "2.0.0" }
   "conf-pkg-config"
   "dune" {>= "2.1"}
   "dune-configurator" {>= "3.10.0"}


### PR DESCRIPTION
The `parse-<lang>` binary (src/run/lib/Main.ml) and the `ocaml-tree-sitter` binary (src/gen/bin/Ocaml_tree_sitter_main.ml) used `Term.info`, `Term.eval`, and `Term.eval_choice`, all of which were removed in cmdliner 2.0. Switch to the modern `Cmd.info` / `Cmd.v` / `Cmd.eval_value` / `Cmd.group` surface.

This unblocks downstream consumers that want to depend on cmdliner 2.x; no behavioral changes intended.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
