### PR TITLE
fix: ensure licence has linking exn

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,24 @@
+This library is distributed under the terms of the GNU LGPL with the
+OCaml linking exception.
+
+----------------------------------------------------------------------
+
+As a special exception to the GNU Library General Public License, you
+may link, statically or dynamically, a "work that uses the Library"
+with a publicly distributed version of the Library to produce an
+executable file containing portions of the Library, and distribute
+that executable file under terms of your choice, without any of the
+additional requirements listed in clause 6 of the GNU Library General
+Public License.  By "a publicly distributed version of the Library",
+we mean either the unmodified Library as distributed by INRIA, or a
+modified version of the Library that is distributed under the
+conditions defined in clause 3 of the GNU Library General Public
+License.  This exception does not however invalidate any other reasons
+why the executable file might be covered by the GNU Library General
+Public License.
+
+----------------------------------------------------------------------
+
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 


### PR DESCRIPTION
After #121 the licence text proper needs to be updated with the linking exn.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
