### PR TITLE
feat: support pattern flags field

### DIFF
--- a/src/gen/lib/CST_grammar_conv.ml
+++ b/src/gen/lib/CST_grammar_conv.ml
@@ -56,7 +56,7 @@ let name_of_body opt_rule_name (body : Tree_sitter_grammar.Rule_body.t) =
   | None ->
       match body with
       | Literal cst -> Some cst
-      | Pattern pat -> Some pat
+      | Pattern { value; _ } -> Some value
       | _ -> None
 
 (*
@@ -150,8 +150,8 @@ let translate ~rule_name (x : Tree_sitter_grammar.Rule_body.t) =
     | Symbol ident -> Symbol ident
     | Literal cst
     | Immediate_token (Literal cst) -> translate_constant rule_name cst
-    | Pattern pat
-    | Immediate_token (Pattern pat) -> translate_pattern rule_name pat
+    | Pattern { value; _ }
+    | Immediate_token (Pattern { value; _ }) -> translate_pattern rule_name value
     | Immediate_token body
     | Token body -> translate_token rule_name body
     | Blank -> Blank

--- a/src/gen/lib/To_JS.ml
+++ b/src/gen/lib/To_JS.ml
@@ -18,8 +18,8 @@ let comma is_last s =
 let str s =
   Yojson.Safe.to_string (`String s)
 
-let pattern s =
-  sprintf "/%s/" s
+let pattern ?flags s =
+  sprintf "/%s/%s" s (Option.value ~default:"" flags)
 
 let rule s =
   sprintf "$.%s" s
@@ -102,7 +102,7 @@ let pp_body ~sort_choices ?prefix ?is_last (body : Rule_body.t) =
       match body with
       | Symbol s -> rule s, None
       | Literal s -> str s, None
-      | Pattern s -> pattern s, None
+      | Pattern { value; flags } -> pattern ?flags value, None
       | Blank -> "\"\" /* blank */", None
       | Repeat x -> "repeat", Some (pp_body x)
       | Repeat1 x -> "repeat1", Some (pp_body x)

--- a/src/gen/lib/Tree_sitter_grammar.ml
+++ b/src/gen/lib/Tree_sitter_grammar.ml
@@ -91,7 +91,7 @@ and Rule_body : sig
   type t =
     | Symbol of ident
     | Literal of string
-    | Pattern of string
+    | Pattern of { value: string; flags: string option }
     | Blank
     | Repeat of t
     | Repeat1 of t
@@ -108,7 +108,7 @@ end = struct
   type t =
     | Symbol of ident
     | Literal of string
-    | Pattern of string
+    | Pattern of { value: string; flags: string option }
     | Blank
     | Repeat of t
     | Repeat1 of t
@@ -133,8 +133,13 @@ end = struct
         `Assoc ["type", `String "BLANK"]
     | Literal value ->
         `Assoc ["type", `String "STRING"; "value", `String value]
-    | Pattern value ->
-        `Assoc ["type", `String "PATTERN"; "value", `String value]
+    | Pattern { value; flags } ->
+        let fields = ["type", `String "PATTERN"; "value", `String value] in
+        let fields = match flags with
+          | None -> fields
+          | Some f -> fields @ ["flags", `String f]
+        in
+        `Assoc fields
     | Symbol name ->
         `Assoc ["type", `String "SYMBOL"; "name", `String name]
     | Seq members ->
@@ -189,7 +194,10 @@ end = struct
       match json |> member "type" |> to_string with
       | "BLANK"          -> Ok Blank
       | "STRING"         -> Ok (Literal (json |> member "value" |> to_string))
-      | "PATTERN"        -> Ok (Pattern (json |> member "value" |> to_string))
+      | "PATTERN"        ->
+          let value = json |> member "value" |> to_string in
+          let flags = json |> member "flags" |> to_string_option in
+          Ok (Pattern { value; flags })
       | "SYMBOL"         -> Ok (Symbol (json |> member "name" |> to_string))
       | "SEQ"            -> parse_members (fun m -> Seq m)
       | "CHOICE"         -> parse_members (fun m -> Choice m)

--- a/src/gen/lib/Tree_sitter_grammar.mli
+++ b/src/gen/lib/Tree_sitter_grammar.mli
@@ -41,7 +41,7 @@ and Rule_body : sig
   type t =
     | Symbol of ident
     | Literal of string
-    | Pattern of string
+    | Pattern of { value: string; flags: string option }
     | Blank
     | Repeat of t
     | Repeat1 of t

--- a/src/gen/lib/Type_name.ml
+++ b/src/gen/lib/Type_name.ml
@@ -86,7 +86,7 @@ let name_ts_rule_body (body : Tree_sitter_grammar.Rule_body.t) =
     | Symbol ident -> ident
     | Literal s -> Punct.to_alphanum s
     | Blank -> "blank"
-    | Pattern pat -> "pat_" ^ name_pattern pat
+    | Pattern { value; _ } -> "pat_" ^ name_pattern value
     | Repeat x -> "rep_" ^ name_rule_body x
     | Repeat1 x -> "rep1_" ^ name_rule_body x
     | Choice (x :: _) -> "choice_" ^ name_rule_body x

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,8 @@ TESTS = \
   reserved \
   inline \
   pattern-name \
-  externals
+  externals \
+  pattern-flags
 
 # Build and run all the tests.
 .PHONY: test

--- a/test/pattern-flags/Makefile
+++ b/test/pattern-flags/Makefile
@@ -1,0 +1,1 @@
+../Makefile.common

--- a/test/pattern-flags/grammar.js
+++ b/test/pattern-flags/grammar.js
@@ -1,0 +1,10 @@
+/*
+  Check that pattern flags (e.g. case-insensitive) are handled correctly.
+*/
+module.exports = grammar({
+  name: 'pattern_flags',
+  rules: {
+    program: $ => repeat($.keyword),
+    keyword: $ => /hello/i,
+  }
+});

--- a/test/pattern-flags/test/ok/capitalizations
+++ b/test/pattern-flags/test/ok/capitalizations
@@ -1,0 +1,3 @@
+hello
+HELLO
+Hello


### PR DESCRIPTION
Add the optional flags field to PATTERN rule bodies, plumbing it through
grammar parsing, CST conversion, and JS code generation, with a test
case for case-insensitive patterns.

Previously we just dropped this when doing a mapping, so if a grammar
had something like `flags: "i"` for a case insensitive rule we would suddenly
become case sensitive after generating the OCaml bindings.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
