### PR TITLE
feat: parametrized building bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,28 @@ The default tree-sitter version to use is in the
 Under the default configuration used for local development purposes,
 the version being actually used is stored in the file
 `tree-sitter-version`. This can be changed by invoking
-`./scripts/switch-tree-sitter-version` before `make setup`.
-We made this available to facilitate the transition from tree-sitter 0.20.6 to
-0.22.6 in ocaml-tree-sitter-semgrep where the integration of some
-grammars needs to be updated. The latest version of these grammars are
-compatible with 0.22.6 but their OCaml integration in Semgrep needs work.
+`./scripts/switch-tree-sitter-version` before `make setup`. Each version
+is installed into its own `tree-sitter-<version>/` directory, and the
+`tree-sitter` symlink points at the currently selected one.
+
+**Scope: this selection affects only this repository's own build** —
+i.e. the tree-sitter runtime that the `ocaml-tree-sitter` code generator
+and its OCaml bindings are compiled against. It is also used to install a
+given version's CLI and runtime library into `tree-sitter-<version>/`.
+
+It does **not** determine which tree-sitter version any downstream
+grammar is built with. In `ocaml-tree-sitter-semgrep`, every grammar is
+pinned to a tree-sitter version by the `lang/languages-<version>` lists
+and built directly against `core/tree-sitter-<version>/`, regardless of
+what `switch-tree-sitter-version` currently points at. Switching versions
+here therefore does not rebuild or invalidate those grammars; it only
+changes core's own runtime and provides a convenient way to install an
+additional version. See the "tree-sitter versions (per language)"
+section of the `ocaml-tree-sitter-semgrep` README.
+
+Because the C API surface we rely on is stable across these versions, a
+single build of the `ocaml-tree-sitter` generator works with grammars
+generated for any of the supported versions.
 
 Documentation
 --

--- a/scripts/download-tree-sitter
+++ b/scripts/download-tree-sitter
@@ -49,7 +49,7 @@ version=$(cat tree-sitter-version)
 # Verify against: https://github.com/tree-sitter/tree-sitter/releases
 expected_checksum() {
   case "$1" in
-    0.20.6) echo "4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de" ;;
+    0.20.8) echo "6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791" ;;
     0.22.6) echo "e2b687f74358ab6404730b7fb1a1ced7ddb3780202d37595ecd7b20a8f41861f" ;;
     0.26.3) echo "7f4a7cf0a2cd217444063fe2a4d800bc9d21ed609badc2ac20c0841d67166550" ;;
     *) error "No checksum registered for tree-sitter $1. Add one to expected_checksum in this script." ;;
@@ -95,7 +95,7 @@ EOF
     fi
 
     case "$version" in
-      0.20.6)
+      0.20.8)
       ;;
       0.22.6)
         # See feat: Windows support using MinGW-w64

--- a/scripts/install-tree-sitter-cli
+++ b/scripts/install-tree-sitter-cli
@@ -6,8 +6,12 @@ set -eu -o pipefail
 
 prog_name=$(basename "$0")
 
-# Installation root for the tree-sitter executable and runtime library
-default_prefix=$(pwd)/tree-sitter
+# Installation root for the tree-sitter executable. Default is the
+# versioned directory so different versions can coexist.
+dir_name=$(dirname "$BASH_SOURCE")
+"$dir_name"/update-version-symlinks
+version=$(cat tree-sitter-version)
+default_prefix=$(pwd)/tree-sitter-"$version"
 
 error() {
   echo "Current directory: $(pwd)" >&2
@@ -47,10 +51,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 bindir="$prefix"/bin
-
-dir_name=$(dirname "$BASH_SOURCE")
-"$dir_name"/update-version-symlinks
-version=$(cat tree-sitter-version)
 
 # Determine platform and architecture for pre-built binary download.
 os=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -6,8 +6,15 @@ set -eu -o pipefail
 
 prog_name=$(basename "$0")
 
-# Installation root for the tree-sitter executable and runtime library
-default_prefix=$(pwd)/tree-sitter
+# Installation root for the tree-sitter executable and runtime library.
+# The default is the versioned directory rather than the 'tree-sitter'
+# symlink so that the dylib's install_name is stamped with the version
+# dir, letting multiple versions coexist (each parser binary loads its
+# own version's libtree-sitter).
+dir_name=$(dirname "$BASH_SOURCE")
+"$dir_name"/update-version-symlinks
+version=$(cat tree-sitter-version)
+default_prefix=$(pwd)/tree-sitter-"$version"
 
 error() {
   echo "Current directory: $(pwd)" >&2
@@ -48,8 +55,6 @@ done
 
 libdir="$prefix"/lib
 
-dir_name=$(dirname "$BASH_SOURCE")
-"$dir_name"/update-version-symlinks
 "$dir_name"/download-tree-sitter --lazy
 
 # We use tree-sitter's Makefile to build the tree-sitter library. It

--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -83,6 +83,25 @@ fi
   make install PREFIX="$prefix" ${CC:+CC=$CC}
 )
 
+# On macOS, re-stamp the installed dylib's install_name so it points at
+# this versioned lib directory (e.g. tree-sitter-0.22.6/lib) rather than
+# the shared 'tree-sitter/' symlink. Otherwise a parser linked against one
+# version loads "tree-sitter/lib/libtree-sitter.<v>.dylib", which dyld
+# resolves through the symlink to whatever version is *currently* selected
+# and fails. This makes the install self-contained and idempotent: each
+# version's parsers always find their own runtime regardless of which
+# version switch-tree-sitter-version currently points at.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  for dylib in "$libdir"/libtree-sitter.*.dylib; do
+    # Skip the symlinks (e.g. libtree-sitter.0.dylib); only re-stamp real files.
+    [[ -f "$dylib" && ! -L "$dylib" ]] || continue
+    install_name_tool -id "$dylib" "$dylib"
+    # The signature is invalidated by the edit; re-sign ad-hoc.
+    codesign --remove-signature "$dylib" 2>/dev/null || true
+    codesign -s - "$dylib" 2>/dev/null || true
+  done
+fi
+
 cat <<EOF
 tree-sitter libraries were installed in:
   $prefix/lib/

--- a/scripts/ocaml-tree-sitter-gen-c
+++ b/scripts/ocaml-tree-sitter-gen-c
@@ -28,18 +28,30 @@ ts_version_at_least() {
     | sort -V -C 2>/dev/null
 }
 
+# Returns 0 if ABI 15 generation is enabled via the environment, 1 otherwise.
+# ABI 15 is off by default: we are not yet ready to ship ABI 15 parsers. See
+# the "tree-sitter ABI 15" section of the repository-root README.
+abi15_enabled() {
+  case "${SEMGREP_ENABLE_ABI15:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Determine the ABI to use for all tree-sitter generate calls.
-# ABI 15 requires >= 0.25.0 and is signalled by a tree-sitter.json file.
+# ABI 15 requires >= 0.25.0, is signalled by a tree-sitter.json file, and is
+# only used when SEMGREP_ENABLE_ABI15 is set.
 # ABI 14 requires >= 0.24.0 (the release that introduced the --abi flag).
 # Older versions use --no-bindings instead.
-if [[ -f tree-sitter.json ]]; then
+if [[ -f tree-sitter.json ]] && abi15_enabled; then
   if ! ts_version_at_least 0.25.0; then
     _s="${BASH_SOURCE[0]}"
     [[ -L "$_s" ]] && _s="$(dirname "$_s")/$(readlink "$_s")"
     script_dir=$(cd "$(dirname "$_s")" && pwd)
     unset _s
     cat >&2 <<EOF
-Error: $name uses ABI 15 (tree-sitter.json present) and requires tree-sitter >= 0.25.0.
+Error: $name uses ABI 15 (tree-sitter.json present, SEMGREP_ENABLE_ABI15 set)
+and requires tree-sitter >= 0.25.0.
 The currently installed version is too old. Switch with:
   $script_dir/switch-tree-sitter-version 0.26.3
 EOF

--- a/scripts/ocaml-tree-sitter-gen-c
+++ b/scripts/ocaml-tree-sitter-gen-c
@@ -21,22 +21,45 @@ EOF
   exit 1
 }
 
+# Returns 0 if the installed tree-sitter version >= $1, 1 otherwise.
+ts_version_at_least() {
+  tree-sitter --version \
+    | sed "s/^tree-sitter \\([0-9.]*\\).*$/$1\\n\\1/" \
+    | sort -V -C 2>/dev/null
+}
+
+# Determine the ABI to use for all tree-sitter generate calls.
+# ABI 15 requires >= 0.25.0 and is signalled by a tree-sitter.json file.
+# ABI 14 requires >= 0.24.0 (the release that introduced the --abi flag).
+# Older versions use --no-bindings instead.
+if [[ -f tree-sitter.json ]]; then
+  if ! ts_version_at_least 0.25.0; then
+    _s="${BASH_SOURCE[0]}"
+    [[ -L "$_s" ]] && _s="$(dirname "$_s")/$(readlink "$_s")"
+    script_dir=$(cd "$(dirname "$_s")" && pwd)
+    unset _s
+    cat >&2 <<EOF
+Error: $name uses ABI 15 (tree-sitter.json present) and requires tree-sitter >= 0.25.0.
+The currently installed version is too old. Switch with:
+  $script_dir/switch-tree-sitter-version 0.26.3
+EOF
+    exit 1
+  fi
+  ts_abi=15
+elif ts_version_at_least 0.24.0; then
+  ts_abi=14
+else
+  ts_abi=""
+fi
+
 tree_sitter_generate() {
-    # Switch on tree sitter version (before/after 0.24.0) due to some
-    # configuration changes. See
-    # <https://github.com/tree-sitter/tree-sitter/commit/b2359e402070445181482f2e351400276d94c968>.
-    if tree-sitter --version \
-      | sed "s/^tree-sitter \\([0-9.]*\\).*$/0.24.0\\n\\1/" \
-      | sort -V -C 2>/dev/null; then
-      # Use ABI 15 if tree-sitter.json exists in this directory (it is required
-      # by tree-sitter to generate ABI 15, so its presence is the natural
-      # signal). Otherwise default to ABI 14.
-      local abi
-      if [[ -f tree-sitter.json ]]; then abi=15; else abi=14; fi
-      tree-sitter generate --abi="$abi" $*
-    else
-      tree-sitter generate --no-bindings $*
-    fi
+  local abi="$1"
+  shift
+  if [[ -n "$abi" ]]; then
+    tree-sitter generate --abi="$abi" "$@"
+  else
+    tree-sitter generate --no-bindings "$@"
+  fi
 }
 
 # Generate C source code for the grammar, in two passes:
@@ -51,7 +74,7 @@ if [[ -e grammar.js ]]; then
   # consist of a local 'grammar.json' file.
 
   echo "$name: Generating initial 'grammar.json' from 'grammar.js'."
-  tree_sitter_generate
+  tree_sitter_generate "$ts_abi"
   mkdir -p src
   if [[ -e orig/LICENSE ]]; then cp -L orig/LICENSE src; fi
   if [[ -e orig/scanner.c ]]; then cp -L orig/scanner.c src; fi
@@ -94,7 +117,7 @@ ocaml-tree-sitter to-js src/grammar.json.orig grammar-rev.js.orig
 ocaml-tree-sitter to-js src/grammar.json grammar-rev.js
 
 echo "$name: Generating definitive 'parser.c'."
-tree_sitter_generate src/grammar.json
+tree_sitter_generate "$ts_abi" src/grammar.json
 
 # Make sure we get an error in case of OOM leading to no src/parser.c
 test -f src/parser.c || error \

--- a/scripts/ocaml-tree-sitter-gen-c
+++ b/scripts/ocaml-tree-sitter-gen-c
@@ -28,11 +28,12 @@ tree_sitter_generate() {
     if tree-sitter --version \
       | sed "s/^tree-sitter \\([0-9.]*\\).*$/0.24.0\\n\\1/" \
       | sort -V -C 2>/dev/null; then
-      # Use ABI 14.
-      # `tree-sitter.json` is required to generate with ABI 15, but we haven't
-      # switched to using this. See also
-      # <https://tree-sitter.github.io/tree-sitter/cli/init>
-      tree-sitter generate --abi=14 $*
+      # Use ABI 15 if tree-sitter.json exists in this directory (it is required
+      # by tree-sitter to generate ABI 15, so its presence is the natural
+      # signal). Otherwise default to ABI 14.
+      local abi
+      if [[ -f tree-sitter.json ]]; then abi=15; else abi=14; fi
+      tree-sitter generate --abi="$abi" $*
     else
       tree-sitter generate --no-bindings $*
     fi

--- a/scripts/switch-tree-sitter-version
+++ b/scripts/switch-tree-sitter-version
@@ -8,7 +8,7 @@ set -eu
 error() {
   (
     echo "[$0] Error: $*"
-    echo "Supported versions: 0.20.6 0.22.6 0.26.3"
+    echo "Supported versions: 0.20.8 0.22.6 0.26.3"
   )
   exit 1
 }
@@ -19,8 +19,8 @@ fi
 
 version=''
 case "$1" in
-  0.20.6)
-    version=0.20.6
+  0.20.8)
+    version=0.20.8
     ;;
   0.22.6)
     version=0.22.6

--- a/scripts/switch-tree-sitter-version
+++ b/scripts/switch-tree-sitter-version
@@ -1,7 +1,13 @@
 #! /usr/bin/env bash
 #
-# Change the tree-sitter version used for local development and rebuild
-# what's necessary.
+# Change the tree-sitter version that THIS repository builds its own
+# OCaml runtime against, and that gets installed into tree-sitter-<version>/.
+#
+# This does NOT affect which tree-sitter version downstream grammars are
+# built with. In ocaml-tree-sitter-semgrep, each grammar is pinned via the
+# lang/languages-<version> lists and built directly against
+# core/tree-sitter-<version>/, independently of this selection. See the
+# "tree-sitter version" section of README.md.
 #
 set -eu
 
@@ -35,4 +41,8 @@ esac
 echo "$version" > tree-sitter-version
 ./scripts/update-version-symlinks
 
+echo "Selected tree-sitter $version for core's own build."
 echo "You can now run 'make setup' to download and build tree-sitter $version."
+echo "Note: this does not change the tree-sitter version used to build"
+echo "downstream grammars; those are pinned per-language in"
+echo "ocaml-tree-sitter-semgrep's lang/languages-* lists."


### PR DESCRIPTION
Multiple changes combined with changes in ocaml-tree-sitter-semgrep.

* Pick ABI 15 whenever `tree-sitter.json` is present and `SEMGREP_ENABLE_ABI15` is specified
* Updated tree-sitter 0.20.6 to 0.20.8 because arm64 mac builds weren't available before that.
* 
 
### Security

- [ ] Change has no security implications (otherwise, ping the security team)
