### PR TITLE
feat: Replace tree-sitter 0.20.6 with 0.20.8

### DIFF
--- a/scripts/download-tree-sitter
+++ b/scripts/download-tree-sitter
@@ -49,7 +49,7 @@ version=$(cat tree-sitter-version)
 # Verify against: https://github.com/tree-sitter/tree-sitter/releases
 expected_checksum() {
   case "$1" in
-    0.20.6) echo "4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de" ;;
+    0.20.8) echo "6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791" ;;
     0.22.6) echo "e2b687f74358ab6404730b7fb1a1ced7ddb3780202d37595ecd7b20a8f41861f" ;;
     0.26.3) echo "7f4a7cf0a2cd217444063fe2a4d800bc9d21ed609badc2ac20c0841d67166550" ;;
     *) error "No checksum registered for tree-sitter $1. Add one to expected_checksum in this script." ;;
@@ -95,7 +95,7 @@ EOF
     fi
 
     case "$version" in
-      0.20.6)
+      0.20.8)
       ;;
       0.22.6)
         # See feat: Windows support using MinGW-w64

--- a/scripts/switch-tree-sitter-version
+++ b/scripts/switch-tree-sitter-version
@@ -8,7 +8,7 @@ set -eu
 error() {
   (
     echo "[$0] Error: $*"
-    echo "Supported versions: 0.20.6 0.22.6 0.26.3"
+    echo "Supported versions: 0.20.8 0.22.6 0.26.3"
   )
   exit 1
 }
@@ -19,8 +19,8 @@ fi
 
 version=''
 case "$1" in
-  0.20.6)
-    version=0.20.6
+  0.20.8)
+    version=0.20.8
     ;;
   0.22.6)
     version=0.22.6


### PR DESCRIPTION
0.20.6 has no macOS-arm64 prebuilt, so `make setup` fails on Apple
Silicon. Switch the supported 0.20.x to 0.20.8 (same C API): update the
checksum table in `download-tree-sitter` and the allowlist in
`switch-tree-sitter-version`.

Consumed by ocaml-tree-sitter-semgrep PR semgrep/ocaml-tree-sitter-semgrep#601.