### PR TITLE
ci: replace pre-commit/action with inlined pinned run [SEC-2493]

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,4 +22,18 @@ jobs:
           opam install -y ocp-indent
           echo "$(opam var bin)" >> "$GITHUB_PATH"
 
-      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: .pre-commit-config.yaml
+          version: "0.11.x"
+      - name: Cache pre-commit hook envs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-v1|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install and run pre-commit
+        run: |
+          UV_EXCLUDE_NEWER="1 week" uv tool install pre-commit --with pre-commit-uv
+          pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
Removes the transitively-unpinned `pre-commit/action`

Similar to: https://github.com/semgrep/semgrep-rules/pull/4017/changes